### PR TITLE
chore: migrate from vercel-labs to vercel org

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": [
-    "@changesets/changelog-github",
-    { "repo": "vercel-labs/error" }
-  ],
+  "changelog": ["@changesets/changelog-github", { "repo": "vercel/error" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 ### Patch Changes
 
-- [#1](https://github.com/vercel-labs/error/pull/1) [`5aa735a`](https://github.com/vercel-labs/error/commit/5aa735a754b95c94e71e8c614c0f696c7084a153) Thanks [@runewolf7](https://github.com/runewolf7)! - Initial alpha release
+- [#1](https://github.com/vercel/error/pull/1) [`5aa735a`](https://github.com/vercel/error/commit/5aa735a754b95c94e71e8c614c0f696c7084a153) Thanks [@runewolf7](https://github.com/runewolf7)! - Initial alpha release

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Unified error primitives for humans and agents",
   "author": "Vercel",
   "repository": {
-    "url": "git+https://github.com/vercel-labs/error.git"
+    "url": "git+https://github.com/vercel/error.git"
   },
   "publishConfig": {
     "access": "restricted",

--- a/src/from-error-response/index.ts
+++ b/src/from-error-response/index.ts
@@ -25,7 +25,7 @@ export type FromErrorResponseOptions = Omit<
  *
  * @example
  * ```ts
- * import { parseErrorResponse, fromErrorResponse } from '@vercel-labs/error/client';
+ * import { parseErrorResponse, fromErrorResponse } from '@vercel/error/client';
  *
  * const res = await fetch('https://api.vercel.com/v1/deployments');
  * if (!res.ok) {


### PR DESCRIPTION
## Summary

- Update all repository references from `vercel-labs/error` to `vercel/error`
- Fix import path in doc example (`@vercel-labs/error` → `@vercel/error`)
- Update CHANGELOG links


Made with [Cursor](https://cursor.com)