### PR TITLE
docs: clarify metadata description

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Every `VercelError` field falls into one of three groups.
 
 | Field        | Type                                                 | Description                                                                                            |
 | ------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `metadata`   | `Record<string, SerializableValue>`                  | Structured context for debugging and logging. Supports arbitrary nesting. Never serialized to the wire |
+| `metadata`   | `Record<string, SerializableValue>`                  | Structured context for debugging and logging. Supports arbitrary nesting. Server-side only — excluded from HTTP error responses |
 | `attributes` | `Record<string, string \| number \| boolean \| ...>` | Flat key-value pairs for OpenTelemetry spans, Sentry tags, and metrics dashboards                      |
 | `requestId`  | `string`                                             | Correlation ID for tracing an error across services                                                    |
 | `cause`      | `unknown`                                            | Standard Error `cause` for chaining. Passed through to `super()` and walkable via `getRootCause`       |

--- a/README.md
+++ b/README.md
@@ -105,12 +105,12 @@ Every `VercelError` field falls into one of three groups.
 
 ### Observability
 
-| Field        | Type                                                 | Description                                                                                            |
-| ------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Field        | Type                                                 | Description                                                                                                                     |
+| ------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `metadata`   | `Record<string, SerializableValue>`                  | Structured context for debugging and logging. Supports arbitrary nesting. Server-side only — excluded from HTTP error responses |
-| `attributes` | `Record<string, string \| number \| boolean \| ...>` | Flat key-value pairs for OpenTelemetry spans, Sentry tags, and metrics dashboards                      |
-| `requestId`  | `string`                                             | Correlation ID for tracing an error across services                                                    |
-| `cause`      | `unknown`                                            | Standard Error `cause` for chaining. Passed through to `super()` and walkable via `getRootCause`       |
+| `attributes` | `Record<string, string \| number \| boolean \| ...>` | Flat key-value pairs for OpenTelemetry spans, Sentry tags, and metrics dashboards                                               |
+| `requestId`  | `string`                                             | Correlation ID for tracing an error across services                                                                             |
+| `cause`      | `unknown`                                            | Standard Error `cause` for chaining. Passed through to `super()` and walkable via `getRootCause`                                |
 
 ## Error factories
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export type SerializableValue =
 
 /**
  * Domain-specific structured context for debugging and logging.
- * Can contain arbitrarily nested values. Never serialized to the wire.
+ * Can contain arbitrarily nested values. Server-side only — excluded from HTTP error responses.
  *
  * Route to: serialization, logging, debugging tools.
  *


### PR DESCRIPTION
## Summary
- Replaces the vague "Never serialized to the wire" description for `metadata` with "Server-side only — excluded from HTTP error responses" in both the README and the `ErrorMetadata` type doc.

## Test plan
- Documentation-only change, no behavior change.

Made with [Cursor](https://cursor.com)