### PR TITLE
fix: switch to NPM token auth for private package publishing

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "public",
+  "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,5 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [],
-  "minimumReleaseAge": 2880
+  "ignore": []
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "minimumReleaseAge": 2880
 }

--- a/.changeset/initial-alpha.md
+++ b/.changeset/initial-alpha.md
@@ -1,0 +1,5 @@
+---
+"@vercel/error": patch
+---
+
+Initial alpha release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,11 @@ name: Release
 # satisfies the "Commits must have verified signatures" repository rule
 # without any GPG key management or bypass exceptions.
 #
-# Publishing to npm is enabled via the npm Trusted Publisher mechanism.
-# The workflow filename (`release.yml`) is bound to the publisher config on
-# npm.com — renaming or replacing this file will break publishing until the
-# npm-side setting is updated to match.
-#
-# See https://docs.npmjs.com/trusted-publishers for the publisher binding.
+# Publishing to npm uses an automation token (NPM_TOKEN_ELEVATED).
+# We would prefer npm Trusted Publishing (provenance via OIDC), but npm
+# only supports it for public packages on public GitHub repos. Since this
+# is an internal private package, we fall back to token-based auth.
+# See https://docs.npmjs.com/trusted-publishers for details.
 
 on:
   push:
@@ -25,11 +24,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
     steps:
-      # Third-party actions in this privileged job are pinned to full
-      # commit SHAs so a moved tag or compromised upstream cannot inject
-      # code into a workflow holding contents:write + id-token:write.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -74,5 +69,5 @@ jobs:
           title: "chore: release"
           commitMode: github-api
         env:
-          NPM_CONFIG_PROVENANCE: "true"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 ### Patch Changes
 
-- [#2](https://github.com/vercel/error/pull/2) [`5aa735a`](https://github.com/vercel/error/commit/5aa735a754b95c94e71e8c614c0f696c7084a153) Thanks [@runewolf7](https://github.com/runewolf7)! - Initial alpha release
+- [#2](https://github.com/vercel/error/pull/2) [`4aee822`](https://github.com/vercel/error/commit/4aee8229fb61cc48bc26815b58064c97a5030e60) Thanks [@runewolf7](https://github.com/runewolf7)! - Initial alpha release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,7 @@
 # @vercel/error
 
-## 0.0.2
+## 0.0.1
 
 ### Patch Changes
 
-- [#1](https://github.com/vercel/error/pull/1) [`5aa735a`](https://github.com/vercel/error/commit/5aa735a754b95c94e71e8c614c0f696c7084a153) Thanks [@runewolf7](https://github.com/runewolf7)! - Initial alpha release
-
-## 0.0.1
-
-- Manual publish to establish Trusted Publishing
+- [#2](https://github.com/vercel/error/pull/2) [`5aa735a`](https://github.com/vercel/error/commit/5aa735a754b95c94e71e8c614c0f696c7084a153) Thanks [@runewolf7](https://github.com/runewolf7)! - Initial alpha release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,0 @@
-# @vercel/error
-
-## 0.0.1
-
-### Patch Changes
-
-- [#2](https://github.com/vercel/error/pull/2) [`4aee822`](https://github.com/vercel/error/commit/4aee8229fb61cc48bc26815b58064c97a5030e60) Thanks [@runewolf7](https://github.com/runewolf7)! - Initial alpha release

--- a/package.json
+++ b/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@vercel/error",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "description": "A lightweight toolkit for structured, actionable errors for humans and agents",
   "author": "Vercel",
   "repository": {
     "url": "git+https://github.com/vercel/error.git"
   },
   "publishConfig": {
-    "access": "public",
-    "provenance": true
+    "access": "restricted"
   },
   "type": "module",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/error",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "A lightweight toolkit for structured, actionable errors for humans and agents",
   "author": "Vercel",
   "repository": {


### PR DESCRIPTION
## Summary

npm Trusted Publishing only works for public packages on public GitHub repos. Since `@vercel/error` is a private internal package, we switch to token-based auth and reset for a clean first release.

- **Release workflow**: replace OIDC trusted publishing with `NPM_TOKEN_ELEVATED` token auth
- **Version reset**: `0.0.0` with a pending changeset — merging this PR triggers a "chore: release" PR that bumps to `0.0.1`
- **Access**: `publishConfig` and changeset config set to `restricted`

> We'd prefer Trusted Publishing for provenance guarantees, but npm doesn't support it for our use case.

## Test plan
- [ ] CI passes
- [ ] After merge, changesets/action opens a "chore: release" PR bumping to 0.0.1
- [ ] Merging the release PR successfully publishes to npm via `NPM_TOKEN_ELEVATED`