### PR TITLE
fix: use NPM_TOKEN for changesets publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,4 +70,4 @@ jobs:
           commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}


### PR DESCRIPTION
## Summary

`changesets/action` expects `NPM_TOKEN`, not `NODE_AUTH_TOKEN`. Fixes the publish step that failed after merging #4.

## Test plan
- [x] CI passes
- [x] Merge this before the pending "chore: release" PR, then merge that to publish 0.0.1

Made with [Cursor](https://cursor.com)