### PR TITLE
fix(security): harden release workflow and sanitize terminal output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,22 +13,31 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+# Default to read-only for the whole workflow. The publish job opts into
+# id-token: write explicitly so the OIDC publishing identity is never
+# available while running untrusted-adjacent steps (deps, build, tests).
+permissions:
+  contents: read
+
 jobs:
-  release:
+  # Re-run the full validation gate on the merge commit before doing
+  # anything release-related. Branch protection covers the PR's HEAD,
+  # but flaky tests, dep drift, or admin merges can let a broken commit
+  # land on main. Anything publish-worthy must pass these checks first.
+  validate:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-      
     steps:
-      - uses: actions/checkout@v6
+      # Actions are pinned to full commit SHAs (not mutable tags) so a moved
+      # tag or compromised action release cannot inject code into the release
+      # pipeline. Trailing comment records the human-readable version.
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           fetch-depth: 0
           lfs: true
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           cache: "pnpm"
@@ -36,10 +45,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Re-run the full validation gate on the merge commit before doing
-      # anything release-related. Branch protection covers the PR's HEAD,
-      # but flaky tests, dep drift, or admin merges can let a broken commit
-      # land on main. Anything publish-worthy must pass these checks first.
       - name: Format
         run: pnpm format
 
@@ -55,5 +60,30 @@ jobs:
       - name: Unit tests
         run: pnpm test
 
+  publish:
+    needs: validate
+    runs-on: ubuntu-latest
+    # id-token: write is scoped to this job only. It runs after validate has
+    # passed and performs the minimum work needed to publish.
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      - uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # prepublishOnly runs the build; npm publish uses OIDC Trusted Publishing.
       - name: Publish to npm
         run: npm publish

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@
 .cursor
 !.cursor/commands
 !.cursor/skills
+.deepsec
 .env
 .env*.local
+.logs
 .turbo
 .vercel
 node_modules/

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A lightweight toolkit for structured, actionable errors for humans and agents",
   "author": "Vercel",
   "repository": {
-    "url": "git+https://github.com/vercel/error.git"
+    "url": "git+https://github.com/vercel-labs/error.git"
   },
   "publishConfig": {
     "access": "restricted"

--- a/src/format/index.spec.ts
+++ b/src/format/index.spec.ts
@@ -193,4 +193,63 @@ describe('format', () => {
       expect(typeof result.color).toBe('boolean');
     });
   });
+
+  describe('control-character sanitization', () => {
+    const ESC = '\x1b';
+
+    it('strips ANSI/CSI escape sequences from hint', () => {
+      const result = hint(`${ESC}[31mred${ESC}[0m`);
+      expect(result).toBe('hint: red');
+      expect(result).not.toContain(ESC);
+    });
+
+    it('strips escape sequences from fix', () => {
+      const result = fix(`do ${ESC}[2K this`);
+      expect(result).toBe('fix: do  this');
+      expect(result).not.toContain(ESC);
+    });
+
+    it('strips OSC 8 hyperlink sequences from link', () => {
+      const result = link(`${ESC}]8;;https://evil.example${ESC}\\text`);
+      expect(result).not.toContain(ESC);
+      expect(result).toContain('read more:');
+    });
+
+    it('strips OSC 52 clipboard sequences from frame header', () => {
+      const result = frame(`${ESC}]52;c;ZXZpbA==${ESC}\\title`);
+      expect(result).not.toContain(ESC);
+    });
+
+    it('strips control chars from frame sections', () => {
+      const result = frame('header', [`bad${ESC}[1mline`]);
+      expect(result).not.toContain(ESC);
+      expect(result).toContain('badline');
+    });
+
+    it('strips escape sequences from every formatAuto field', () => {
+      const result = formatAuto({
+        code: `code${ESC}[0m`,
+        fix: `fix${ESC}[0m`,
+        hint: `hint${ESC}[0m`,
+        link: `https://x${ESC}[0m`,
+        message: `msg${ESC}[31m`,
+        name: `Vercel${ESC}[1mError`,
+        reason: `reason${ESC}[2K`,
+        scope: `scope${ESC}]52;c;x${ESC}\\`,
+      });
+      expect(result).not.toContain(ESC);
+      expect(result).toContain('msg');
+      expect(result).toContain('reason');
+    });
+
+    it('strips DEL and C1 control characters', () => {
+      const result = hint('a\x7fb\x9bc');
+      expect(result).toBe('hint: abc');
+    });
+
+    it('preserves tab, newline, and carriage return', () => {
+      const result = hint('line1\tcol\nline2\r');
+      expect(result).toBe('hint: line1\tcol\nline2\r');
+    });
+  });
 });

--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -5,6 +5,9 @@
 /**
  * Render a Unicode tree frame with auto-detected formatting.
  *
+ * Terminal control sequences in `header` and `sections` are stripped
+ * (see {@link sanitize}).
+ *
  * @param header - The main error message line
  * @param sections - Detail lines (falsy values are filtered out)
  */
@@ -13,37 +16,48 @@ export function frame(
   sections?: (string | undefined | null | false)[],
 ): string {
   const { tree, color } = detectFormat();
-  return renderFrame({ color, header, sections, tree });
+  return renderFrame({
+    color,
+    header: sanitize(header),
+    sections: sections?.map((s) => (typeof s === 'string' ? sanitize(s) : s)),
+    tree,
+  });
 }
 
 /**
  * Format a string as a hint. Nil-safe — returns `undefined` if falsy.
+ *
+ * Terminal control sequences in `text` are stripped (see {@link sanitize}).
  */
 export function hint(text: string | undefined | null): string | undefined {
   if (!text) {
     return undefined;
   }
-  return `hint: ${text}`;
+  return `hint: ${sanitize(text)}`;
 }
 
 /**
  * Format a string as a fix suggestion. Nil-safe — returns `undefined` if falsy.
+ *
+ * Terminal control sequences in `text` are stripped (see {@link sanitize}).
  */
 export function fix(text: string | undefined | null): string | undefined {
   if (!text) {
     return undefined;
   }
-  return `fix: ${text}`;
+  return `fix: ${sanitize(text)}`;
 }
 
 /**
  * Format a URL as a link. Nil-safe — returns `undefined` if falsy.
+ *
+ * Terminal control sequences in `url` are stripped (see {@link sanitize}).
  */
 export function link(url: string | undefined | null): string | undefined {
   if (!url) {
     return undefined;
   }
-  return `read more: ${url}`;
+  return `read more: ${sanitize(url)}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -97,12 +111,10 @@ export function formatAuto(error: ErrorShape): string {
   const { tree, color } = detectFormat();
   const header = buildHeader(error, color);
 
-  const sections = [
-    error.reason,
-    hint(error.hint),
-    fix(error.fix),
-    link(error.link),
-  ];
+  const reason =
+    error.reason !== undefined ? sanitize(error.reason) : undefined;
+
+  const sections = [reason, hint(error.hint), fix(error.fix), link(error.link)];
 
   return renderFrame({ color, header, sections, tree });
 }
@@ -120,6 +132,36 @@ interface ErrorShape {
   hint?: string;
   fix?: string;
   link?: string;
+}
+
+/**
+ * Matches complete ANSI escape sequences introduced by `ESC` (0x1b): CSI
+ * (`ESC [ … final`), OSC (`ESC ] … BEL/ST`, e.g. OSC 8 hyperlinks and OSC 52
+ * clipboard), and other two/three-byte escapes. Removing the whole sequence —
+ * not just the `ESC` byte — keeps the visible text clean.
+ */
+/* oxlint-disable no-control-regex -- intentional terminal control-char matching */
+const ANSI_ESCAPE =
+  /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][\s\S]*?(?:\x07|\x1b\\)|[@-Z\\-_])/g;
+
+/**
+ * Matches standalone terminal control characters left after ANSI sequences are
+ * removed: C0 controls (except `\t`, `\n`, `\r`), the C1 range, and `DEL`.
+ */
+const CONTROL_CHARS = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]/g;
+/* oxlint-enable no-control-regex */
+
+/**
+ * Strip terminal control sequences from caller-controlled text before it is
+ * rendered to a terminal. Error fields can originate from an untrusted upstream
+ * (e.g. an HTTP error body parsed by `parseErrorResponse`); without this a
+ * malicious upstream could inject escape sequences that rewrite the screen,
+ * forge log lines, or abuse terminal features (OSC 8 links, OSC 52 clipboard).
+ * Full ANSI sequences are removed first, then any leftover control bytes.
+ * Preserves `\t`, `\n`, `\r`.
+ */
+function sanitize(text: string): string {
+  return text.replace(ANSI_ESCAPE, '').replace(CONTROL_CHARS, '');
 }
 
 const ANSI = {
@@ -151,21 +193,24 @@ const ACTIONABLE_PREFIXES = ['hint: ', 'fix: ', 'read more: '] as const;
  * ANSI:            `error:` red+bold, name red, `[qualifier]` red, message red+bold
  */
 function buildHeader(error: ErrorShape, color: boolean): string {
-  const qualifier = [error.scope, error.code].filter(Boolean).join(':');
+  const name = sanitize(error.name);
+  const message = sanitize(error.message);
+  const qualifier = [error.scope, error.code]
+    .filter((part): part is string => Boolean(part))
+    .map(sanitize)
+    .join(':');
   const plain = qualifier
-    ? `error: ${error.name} [${qualifier}] ${error.message}`
-    : `error: ${error.name}: ${error.message}`;
+    ? `error: ${name} [${qualifier}] ${message}`
+    : `error: ${name}: ${message}`;
 
   if (!color) {
     return plain;
   }
 
   const label = `${ANSI.red}${ANSI.bold}error:${ANSI.resetBold}`;
-  const name = `${ANSI.red}${error.name}`;
   const tag = qualifier ? ` [${qualifier}]` : ':';
-  const message = `${ANSI.bold}${error.message}${ANSI.reset}`;
 
-  return `${label} ${name}${tag} ${message}`;
+  return `${label} ${ANSI.red}${name}${tag} ${ANSI.bold}${message}${ANSI.reset}`;
 }
 
 function filterSections(
@@ -201,6 +246,12 @@ function isActionable(line: string): boolean {
   return ACTIONABLE_PREFIXES.some((prefix) => line.startsWith(prefix));
 }
 
+/**
+ * Render the final framed output. Inputs must already be {@link sanitize}d:
+ * this stage applies the library's own ANSI styling (`colorizeLine`,
+ * connectors), so it cannot strip control characters without destroying that
+ * styling. Callers (`frame`, `formatAuto`) own sanitization of untrusted text.
+ */
 function renderFrame({
   header,
   sections,


### PR DESCRIPTION
## Summary
Fixes two issues found by a `deepsec` scan.

### 🔴 HIGH — Release workflow hardening
`release.yml` used mutable action tags while holding npm publish (OIDC) rights.
- Pinned all actions to commit SHAs.
- Split into `validate` + `publish` so `id-token: write` is scoped to publishing only; workflow defaults to read-only.

### 🟡 MEDIUM — Terminal output sanitization
Untrusted error fields could reach the terminal without stripping control sequences (ANSI/OSC injection).
- Added `sanitize()` and applied it at every formatter render boundary.
- Added tests for control-sequence stripping (and tab/newline preservation).

## Housekeeping
- `package.json` `repository.url` → `vercel-labs/error`; ignore `.deepsec`.

## Validation
`pnpm validate`: lint, format, typecheck, 171 tests ✅.