### PR TITLE
feat(create-errors): optional scope, docsBaseUrl, and prod-fallback rendering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # prepublishOnly runs the build; npm publish uses OIDC Trusted Publishing.
+      # prepublishOnly runs the build; npm publish uses OIDC Trusted Publishing
+      # (needs npm >= 11.5.1, already bundled with the pinned Node 24).
       - name: Publish to npm
         run: npm publish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,3 +51,7 @@ src/<fn-name>/index.spec.ts  # Tests
 3. **Framework-agnostic**: should work with any HTTP framework
 4. **No external runtime dependencies**. Do not install any third party runtime dependencies in this package
 5. **Avoid circular dependencies**: Never introduce circular dependencies
+
+## Changelog
+
+When asked to update the changelog, keep each entry to a single concise line. State what changed, not how. Group entries under the target version heading with a `### Patch Changes` (or `Minor`/`Major`) subheading.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @vercel/error
 
+## 0.0.2
+
+### Patch Changes
+
+- `createErrors`: `scope` is now optional, so the factory works with no arguments.
+- `createErrors`: add `docsBaseUrl` to derive each error's `link` from its `code`. The code is appended verbatim; pass a function for custom shaping. An explicit per-error `link` always wins.
+- Render a stripped error (empty message) by its `[scope:code]` identifier in both the terminal formatter and the HTTP wire format.
+- Annotate every error option and document `code` style guidance (semantic, numeric, or namespaced).
+- Publish the package publicly on npm.
+
 ## 0.0.1
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Patch Changes
 
-- `createErrors`: `scope` is now optional, so the factory works with no arguments.
-- `createErrors`: add `docsBaseUrl` to derive each error's `link` from its `code`. The code is appended verbatim; pass a function for custom shaping. An explicit per-error `link` always wins.
-- Render a stripped error (empty message) by its `[scope:code]` identifier in both the terminal formatter and the HTTP wire format.
-- Annotate every error option and document `code` style guidance (semantic, numeric, or namespaced).
-- Publish the package publicly on npm.
+- `createErrors`: `scope` is now optional.
+- `createErrors`: add `docsBaseUrl` to derive `link` from `code`.
+- Render stripped errors by their `[scope:code]` identifier.
+- Annotate every error option and document `code` styles.
+- Publish publicly on npm.
 
 ## 0.0.1
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@vercel/error",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A lightweight toolkit for structured, actionable errors for humans and agents",
   "author": "Vercel",
   "repository": {
     "url": "git+https://github.com/vercel-labs/error.git"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "type": "module",
   "sideEffects": false,

--- a/src/create-errors/index.spec.ts
+++ b/src/create-errors/index.spec.ts
@@ -11,6 +11,25 @@ describe('createErrors', () => {
     expect(errors.report).toBeTypeOf('function');
   });
 
+  describe('optional scope', () => {
+    it('works with no options at all', () => {
+      const errors = createErrors();
+      const error = errors.create('failed');
+      expect(error).toBeInstanceOf(VercelError);
+      expect(error.scope).toBeUndefined();
+      expect(error.message).toBe('failed');
+    });
+
+    it('works when options are provided without a scope', () => {
+      const report = vi.fn();
+      const errors = createErrors({ report });
+      const error = errors.report('boom', { code: 'oops' });
+      expect(error.scope).toBeUndefined();
+      expect(error.code).toBe('oops');
+      expect(report).toHaveBeenCalledWith(error);
+    });
+  });
+
   describe('create', () => {
     it('creates a VercelError with scope applied', () => {
       const errors = createErrors({ scope: 'auth' });
@@ -189,6 +208,66 @@ describe('createErrors', () => {
       const error = errors.create('test');
       expect(error).toBeInstanceOf(VercelError);
       expect(error.constructor).toBe(VercelError);
+    });
+  });
+
+  describe('docsBaseUrl', () => {
+    it('derives link from a string base and the code', () => {
+      const errors = createErrors({
+        docsBaseUrl: 'https://vercel.com/docs/errors/db',
+        scope: 'db',
+      });
+      const error = errors.create('fail', { code: 'pool_exhausted' });
+      expect(error.link).toBe(
+        'https://vercel.com/docs/errors/db/pool_exhausted',
+      );
+    });
+
+    it('lowercases the code in the derived link', () => {
+      const errors = createErrors({ docsBaseUrl: 'https://e.dev' });
+      const error = errors.create('fail', { code: 'Pool_Exhausted' });
+      expect(error.link).toBe('https://e.dev/pool_exhausted');
+    });
+
+    it('trims trailing slashes from a string base', () => {
+      const errors = createErrors({ docsBaseUrl: 'https://e.dev/errors//' });
+      const error = errors.create('fail', { code: 'timeout' });
+      expect(error.link).toBe('https://e.dev/errors/timeout');
+    });
+
+    it('derives link from a function base', () => {
+      const errors = createErrors({
+        docsBaseUrl: (code) => `https://e.dev/${code}?ref=docs`,
+      });
+      const error = errors.create('fail', { code: 'timeout' });
+      expect(error.link).toBe('https://e.dev/timeout?ref=docs');
+    });
+
+    it('skips derivation when there is no code', () => {
+      const errors = createErrors({ docsBaseUrl: 'https://e.dev' });
+      const error = errors.create('fail');
+      expect(error.link).toBeUndefined();
+    });
+
+    it('lets an explicit per-error link win over docsBaseUrl', () => {
+      const errors = createErrors({ docsBaseUrl: 'https://e.dev' });
+      const error = errors.create('fail', {
+        code: 'timeout',
+        link: 'https://custom.example/timeout',
+      });
+      expect(error.link).toBe('https://custom.example/timeout');
+    });
+
+    it('skips derivation when the function base returns undefined', () => {
+      const errors = createErrors({ docsBaseUrl: () => undefined });
+      const error = errors.create('fail', { code: 'timeout' });
+      expect(error.link).toBeUndefined();
+    });
+
+    it('does not set a link when docsBaseUrl is not provided', () => {
+      const errors = createErrors({ scope: 'db' });
+      const error = errors.create('fail', { code: 'timeout' });
+      expect(error.link).toBeUndefined();
     });
   });
 });

--- a/src/create-errors/index.spec.ts
+++ b/src/create-errors/index.spec.ts
@@ -223,10 +223,10 @@ describe('createErrors', () => {
       );
     });
 
-    it('lowercases the code in the derived link', () => {
+    it('appends the code verbatim without changing its case', () => {
       const errors = createErrors({ docsBaseUrl: 'https://e.dev' });
-      const error = errors.create('fail', { code: 'Pool_Exhausted' });
-      expect(error.link).toBe('https://e.dev/pool_exhausted');
+      const error = errors.create('fail', { code: 'E1001' });
+      expect(error.link).toBe('https://e.dev/E1001');
     });
 
     it('trims trailing slashes from a string base', () => {

--- a/src/create-errors/index.ts
+++ b/src/create-errors/index.ts
@@ -7,7 +7,7 @@ import { VercelError } from '../vercel-error';
 
 /**
  * Resolve a documentation URL for a code from a base URL.
- * A string base appends the lowercased code as a path segment. A function
+ * A string base appends the code verbatim as a path segment. A function
  * base is called with the code. Returns `undefined` when no URL applies.
  */
 function resolveDocsUrl<TCode extends string>(
@@ -16,7 +16,7 @@ function resolveDocsUrl<TCode extends string>(
 ): string | undefined {
   if (!docsBaseUrl) return undefined;
   if (typeof docsBaseUrl === 'function') return docsBaseUrl(code);
-  return `${docsBaseUrl.replace(/\/+$/, '')}/${code.toLowerCase()}`;
+  return `${docsBaseUrl.replace(/\/+$/, '')}/${code}`;
 }
 
 /**
@@ -59,10 +59,12 @@ export interface CreateErrorsOptions<
 
   /**
    * Base URL or resolver for documentation links. When a string, the error's
-   * `code` is appended as a lowercase path segment
-   * (e.g. `"https://vercel.com/docs/errors"` →
-   * `"https://vercel.com/docs/errors/pool_exhausted"`). When a function,
-   * it receives the `code` and returns a URL, or `undefined` to skip.
+   * `code` is appended verbatim as a path segment
+   * (e.g. `"https://vercel.com/docs/errors"` plus code `"pool_exhausted"` gives
+   * `"https://vercel.com/docs/errors/pool_exhausted"`). The code is not
+   * transformed, so use a function base if you need to change its case or shape.
+   * When a function, it receives the `code` and returns a URL, or `undefined`
+   * to skip.
    *
    * Applied only when an error has a `code` and no explicit `link`. A
    * per-error `link` always wins.

--- a/src/create-errors/index.ts
+++ b/src/create-errors/index.ts
@@ -6,6 +6,20 @@ import type {
 import { VercelError } from '../vercel-error';
 
 /**
+ * Resolve a documentation URL for a code from a base URL.
+ * A string base appends the lowercased code as a path segment. A function
+ * base is called with the code. Returns `undefined` when no URL applies.
+ */
+function resolveDocsUrl<TCode extends string>(
+  docsBaseUrl: string | ((code: TCode) => string | undefined) | undefined,
+  code: TCode,
+): string | undefined {
+  if (!docsBaseUrl) return undefined;
+  if (typeof docsBaseUrl === 'function') return docsBaseUrl(code);
+  return `${docsBaseUrl.replace(/\/+$/, '')}/${code.toLowerCase()}`;
+}
+
+/**
  * Per-error options passed to create/raise/report.
  * `scope` is omitted because it's the factory's identity.
  */
@@ -36,7 +50,25 @@ export interface CreateErrorsOptions<
   TCode extends string = string,
   TError extends VercelError<TCode> = VercelError<TCode>,
 > {
-  scope: string;
+  /**
+   * Namespace injected into every error this factory produces.
+   * Optional. Provide it only when a scope is useful, such as grouping errors
+   * by service or subsystem. When omitted, errors have no `scope`.
+   */
+  scope?: string;
+
+  /**
+   * Base URL or resolver for documentation links. When a string, the error's
+   * `code` is appended as a lowercase path segment
+   * (e.g. `"https://vercel.com/docs/errors"` →
+   * `"https://vercel.com/docs/errors/pool_exhausted"`). When a function,
+   * it receives the `code` and returns a URL, or `undefined` to skip.
+   *
+   * Applied only when an error has a `code` and no explicit `link`. A
+   * per-error `link` always wins.
+   */
+  docsBaseUrl?: string | ((code: TCode) => string | undefined);
+
   ErrorClass?: ErrorConstructor<TCode, TError>;
   attributes?: ErrorAttributes;
   metadata?: ErrorMetadata;
@@ -44,25 +76,16 @@ export interface CreateErrorsOptions<
 }
 
 /**
- * Create a scoped error namespace with type-safe error codes.
+ * Create an error factory with type-safe error codes.
  *
  * Always returns `{ create, raise, report }`.
- * If no `report` callback is provided, `report` defaults to `console.error`.
- * If `ErrorClass` is provided, all errors are instances of that class.
+ * `scope` is optional. Provide it only when you want to group errors by a
+ * namespace. When `docsBaseUrl` is set, each error's `link` is derived from
+ * its `code`, unless you pass an explicit `link`.
+ * When no `report` callback is provided, `report` defaults to `console.error`.
+ * When `ErrorClass` is provided, all errors are instances of that class.
  *
  * @example
- * ```ts
- * const errors = createErrors({
- *   scope: 'database',
- *   report: (error) => sentry.captureException(error),
- * });
- *
- * const error = errors.create('Connection failed', { code: 'conn_failed' });
- * errors.raise('Timeout', { code: 'timeout' }); // throws
- * errors.report('Pool exhausted', { code: 'pool_exhausted' }); // reports + returns
- * ```
- *
- * @example Custom error class
  * ```ts
  * class DatabaseError extends VercelError {
  *   readonly retryable = true;
@@ -71,16 +94,24 @@ export interface CreateErrorsOptions<
  * const errors = createErrors({
  *   scope: 'database',
  *   ErrorClass: DatabaseError,
+ *   docsBaseUrl: 'https://vercel.com/docs/errors/database',
+ *   report: (error) => sentry.captureException(error),
  * });
  *
- * const err = errors.create('Pool exhausted'); // DatabaseError
- * err.retryable; // true — fully typed
+ * const error = errors.create('Connection failed', { code: 'conn_failed' });
+ * error.retryable; // true, fully typed
+ * error.link; // 'https://vercel.com/docs/errors/database/conn_failed'
+ *
+ * errors.raise('Timeout', { code: 'timeout' }); // throws
+ * errors.report('Pool exhausted', { code: 'pool_exhausted' }); // reports + returns
  * ```
  */
 export function createErrors<
   TCode extends string = string,
   TError extends VercelError<TCode> = VercelError<TCode>,
->(options: CreateErrorsOptions<TCode, TError>): ErrorFactory<TCode, TError> {
+>(
+  options: CreateErrorsOptions<TCode, TError> = {},
+): ErrorFactory<TCode, TError> {
   const ErrorClass = (options.ErrorClass ?? VercelError) as ErrorConstructor<
     TCode,
     TError
@@ -101,25 +132,42 @@ export function createErrors<
         ? { ...options.metadata, ...itemOptions.metadata }
         : undefined;
 
+    const link =
+      itemOptions.link ??
+      (itemOptions.code !== undefined
+        ? resolveDocsUrl(options.docsBaseUrl, itemOptions.code)
+        : undefined);
+
     const mergedOptions: VercelErrorOptions<TCode> = {
       ...itemOptions,
       attributes: mergedAttributes,
       metadata: mergedMetadata,
+      link,
       scope: options.scope,
     };
 
     return new ErrorClass(message, mergedOptions);
   }
 
+  function raise(
+    message: string,
+    itemOptions?: CreateErrorOptions<TCode>,
+  ): never {
+    throw create(message, itemOptions);
+  }
+
+  function report(
+    message: string,
+    itemOptions?: CreateErrorOptions<TCode>,
+  ): TError {
+    const error = create(message, itemOptions);
+    reportFn(error);
+    return error;
+  }
+
   return {
     create,
-    raise(message: string, itemOptions?: CreateErrorOptions<TCode>): never {
-      throw create(message, itemOptions);
-    },
-    report(message: string, itemOptions?: CreateErrorOptions<TCode>): TError {
-      const error = create(message, itemOptions);
-      reportFn(error);
-      return error;
-    },
+    raise,
+    report,
   };
 }

--- a/src/format/index.spec.ts
+++ b/src/format/index.spec.ts
@@ -130,7 +130,7 @@ describe('format', () => {
     });
   });
 
-  describe('formatAuto — tree structure', () => {
+  describe('formatAuto: tree structure', () => {
     it('includes spacer line between header and sections', () => {
       const result = formatAuto({
         message: 'fail',
@@ -183,6 +183,53 @@ describe('format', () => {
         name: 'VercelError',
       });
       expect(result).toContain('VercelError:');
+    });
+  });
+
+  describe('formatAuto: stripped message fallback', () => {
+    it('renders the qualifier as the header when message is empty', () => {
+      const result = formatAuto({
+        code: 'pool_exhausted',
+        message: '',
+        name: 'VercelError',
+        scope: 'database',
+      });
+      expect(result).toContain('VercelError [database:pool_exhausted]');
+      expect(result).not.toContain('[database:pool_exhausted] ');
+    });
+
+    it('renders code-only qualifier when message and scope are empty', () => {
+      const result = formatAuto({
+        code: 'timeout',
+        message: '',
+        name: 'VercelError',
+      });
+      expect(result).toContain('VercelError [timeout]');
+    });
+
+    it('renders just the name when message and qualifier are empty', () => {
+      const result = formatAuto({
+        message: '',
+        name: 'VercelError',
+      });
+      const firstLine = result.split('\n')[0];
+      expect(firstLine).toContain('VercelError');
+      expect(firstLine).not.toContain('VercelError:');
+      expect(firstLine).not.toContain('[');
+    });
+
+    it('keeps a surviving link section alongside a stripped message', () => {
+      const result = formatAuto({
+        code: 'pool_exhausted',
+        link: 'https://vercel.com/docs/errors/database/pool_exhausted',
+        message: '',
+        name: 'VercelError',
+        scope: 'database',
+      });
+      expect(result).toContain('VercelError [database:pool_exhausted]');
+      expect(result).toContain(
+        'read more: https://vercel.com/docs/errors/database/pool_exhausted',
+      );
     });
   });
 

--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -25,7 +25,7 @@ export function frame(
 }
 
 /**
- * Format a string as a hint. Nil-safe — returns `undefined` if falsy.
+ * Format a string as a hint. Nil-safe. Returns `undefined` if falsy.
  *
  * Terminal control sequences in `text` are stripped (see {@link sanitize}).
  */
@@ -37,7 +37,7 @@ export function hint(text: string | undefined | null): string | undefined {
 }
 
 /**
- * Format a string as a fix suggestion. Nil-safe — returns `undefined` if falsy.
+ * Format a string as a fix suggestion. Nil-safe. Returns `undefined` if falsy.
  *
  * Terminal control sequences in `text` are stripped (see {@link sanitize}).
  */
@@ -49,7 +49,7 @@ export function fix(text: string | undefined | null): string | undefined {
 }
 
 /**
- * Format a URL as a link. Nil-safe — returns `undefined` if falsy.
+ * Format a URL as a link. Nil-safe. Returns `undefined` if falsy.
  *
  * Terminal control sequences in `url` are stripped (see {@link sanitize}).
  */
@@ -137,8 +137,8 @@ interface ErrorShape {
 /**
  * Matches complete ANSI escape sequences introduced by `ESC` (0x1b): CSI
  * (`ESC [ … final`), OSC (`ESC ] … BEL/ST`, e.g. OSC 8 hyperlinks and OSC 52
- * clipboard), and other two/three-byte escapes. Removing the whole sequence —
- * not just the `ESC` byte — keeps the visible text clean.
+ * clipboard), and other two/three-byte escapes. Removing the whole sequence,
+ * rather than only the `ESC` byte, keeps the visible text clean.
  */
 /* oxlint-disable no-control-regex -- intentional terminal control-char matching */
 const ANSI_ESCAPE =
@@ -188,29 +188,56 @@ const ACTIONABLE_PREFIXES = ['hint: ', 'fix: ', 'read more: '] as const;
 /**
  * Build the error header line.
  *
- * With qualifier:  `error: VercelError [scope:code] message`
- * Without:         `error: VercelError: message`
- * ANSI:            `error:` red+bold, name red, `[qualifier]` red, message red+bold
+ * With qualifier:    `error: VercelError [scope:code] message`
+ * Without:           `error: VercelError: message`
+ * Stripped message:  `error: VercelError [scope:code]` (qualifier only)
+ * No message at all:  `error: VercelError`
+ * ANSI:              `error:` red+bold, name red, `[qualifier]` red, message red+bold
+ *
+ * When `message` is empty, such as after production stripping, the qualifier
+ * stands in for it so the error still identifies itself by `scope` and `code`.
  */
 function buildHeader(error: ErrorShape, color: boolean): string {
-  const name = sanitize(error.name);
-  const message = sanitize(error.message);
-  const qualifier = [error.scope, error.code]
-    .filter((part): part is string => Boolean(part))
-    .map(sanitize)
-    .join(':');
-  const plain = qualifier
-    ? `error: ${name} [${qualifier}] ${message}`
-    : `error: ${name}: ${message}`;
+  const parts: HeaderParts = {
+    name: sanitize(error.name),
+    message: sanitize(error.message),
+    qualifier: [error.scope, error.code]
+      .filter((part): part is string => Boolean(part))
+      .map(sanitize)
+      .join(':'),
+  };
 
-  if (!color) {
-    return plain;
+  return color ? buildColorHeader(parts) : buildPlainHeader(parts);
+}
+
+interface HeaderParts {
+  name: string;
+  qualifier: string;
+  message: string;
+}
+
+function buildPlainHeader({ name, qualifier, message }: HeaderParts): string {
+  if (qualifier) {
+    return message
+      ? `error: ${name} [${qualifier}] ${message}`
+      : `error: ${name} [${qualifier}]`;
+  }
+  return message ? `error: ${name}: ${message}` : `error: ${name}`;
+}
+
+function buildColorHeader({ name, qualifier, message }: HeaderParts): string {
+  const label = `${ANSI.red}${ANSI.bold}error:${ANSI.resetBold}`;
+
+  if (qualifier) {
+    const head = `${label} ${ANSI.red}${name} [${qualifier}]`;
+    return message
+      ? `${head} ${ANSI.bold}${message}${ANSI.reset}`
+      : `${head}${ANSI.reset}`;
   }
 
-  const label = `${ANSI.red}${ANSI.bold}error:${ANSI.resetBold}`;
-  const tag = qualifier ? ` [${qualifier}]` : ':';
-
-  return `${label} ${ANSI.red}${name}${tag} ${ANSI.bold}${message}${ANSI.reset}`;
+  return message
+    ? `${label} ${ANSI.red}${name}: ${ANSI.bold}${message}${ANSI.reset}`
+    : `${label} ${ANSI.red}${name}${ANSI.reset}`;
 }
 
 function filterSections(

--- a/src/from-error-response/index.ts
+++ b/src/from-error-response/index.ts
@@ -4,7 +4,7 @@ import { VercelError } from '../vercel-error';
 /**
  * Additional options when reconstructing a VercelError from an ErrorResponse.
  * Fields already provided by the ErrorResponse (`code`, `reason`, `hint`,
- * `fix`, `link`, `userMessage`) are excluded — the wire values always win.
+ * `fix`, `link`, `userMessage`) are excluded, so the wire values always win.
  */
 export type FromErrorResponseOptions = Omit<
   VercelErrorOptions,

--- a/src/to-error-response/index.spec.ts
+++ b/src/to-error-response/index.spec.ts
@@ -246,4 +246,42 @@ describe('errorResponse', () => {
       expect(response.headers.get('Content-Type')).toBe('application/json');
     });
   });
+
+  describe('stripped message fallback', () => {
+    it('falls back to [scope:code] when a VercelError message is empty', () => {
+      const error = new VercelError('', {
+        code: 'pool_exhausted',
+        scope: 'database',
+        statusCode: 503,
+      });
+      const parsed = parseBody(errorResponse(error).body);
+      expect(parsed.error.message).toBe('[database:pool_exhausted]');
+      expect(parsed.error.code).toBe('pool_exhausted');
+    });
+
+    it('falls back to [code] when message and scope are empty', () => {
+      const error = new VercelError('', { code: 'timeout' });
+      const parsed = parseBody(errorResponse(error).body);
+      expect(parsed.error.message).toBe('[timeout]');
+    });
+
+    it('falls back to [code] for plain params with empty message', () => {
+      const parsed = parseBody(
+        errorResponse({ code: 'not_found', message: '' }).body,
+      );
+      expect(parsed.error.message).toBe('[not_found]');
+    });
+
+    it('renders the qualifier header in the ANSI path when stripped', () => {
+      const error = new VercelError('', {
+        code: 'pool_exhausted',
+        scope: 'database',
+      });
+      const { body } = errorResponse(
+        error,
+        makeRequest({ 'X-Error-Format': 'ansi' }),
+      );
+      expect(body).toContain('VercelError [database:pool_exhausted]');
+    });
+  });
 });

--- a/src/to-error-response/index.ts
+++ b/src/to-error-response/index.ts
@@ -8,18 +8,28 @@ import { wantsAnsi } from '../wants-ansi';
  * Plain error parameters for building a response without a VercelError instance.
  */
 export interface ErrorResponseParams {
+  /** HTTP status code for the response. Defaults to 500. */
   status?: number;
+  /** Stable, machine-readable identifier for this error. */
   code?: string;
+  /** Client-safe message describing what happened. */
   message: string;
+  /** Why the error happened, the root-cause explanation. */
   reason?: string;
+  /** Advisory tip that helps the developer, shown before `fix`. */
   hint?: string;
+  /** Actionable step that resolves the error. */
   fix?: string;
+  /** URL to documentation for this error. */
   link?: string;
 }
 
 export interface ErrorResponseResult {
+  /** HTTP status code to send. */
   status: number;
+  /** Serialized response body, either JSON or structured text. */
   body: string;
+  /** Content-Type and any other headers to spread into the response. */
   headers: Record<string, string>;
 }
 

--- a/src/to-error-response/index.ts
+++ b/src/to-error-response/index.ts
@@ -29,7 +29,7 @@ const TEXT_HEADERS = { 'Content-Type': 'text/plain; charset=utf-8' } as const;
 /**
  * Build a complete HTTP error response from a VercelError or plain parameters.
  *
- * Returns `{ status, body, headers }` — spread `headers` directly into your
+ * Returns `{ status, body, headers }`. Spread `headers` directly into your
  * framework's response constructor. Content negotiation is handled internally
  * when a request or headers object is provided.
  *
@@ -43,7 +43,7 @@ const TEXT_HEADERS = { 'Content-Type': 'text/plain; charset=utf-8' } as const;
  *
  * @example
  * ```ts
- * // Minimal — always JSON
+ * // Minimal: always JSON
  * const { status, body, headers } = errorResponse(error);
  * return new Response(body, { status, headers });
  *
@@ -92,9 +92,34 @@ interface ExtractedData {
 }
 
 function buildPlainHeader(error: ErrorResponse['error']): string {
+  if (!error.message) {
+    return error.code ? `error: [${error.code}]` : 'error:';
+  }
   return error.code
     ? `error: [${error.code}] ${error.message}`
     : `error: ${error.message}`;
+}
+
+interface WireMessageParts {
+  message: string;
+  scope?: string;
+  code?: string;
+}
+
+/**
+ * Resolve the client-facing wire message. After production stripping the
+ * message can be empty, so fall back to a `[scope:code]` identifier built from
+ * whatever structured fields survive. The wire format omits `scope`, so it is
+ * folded into the message here.
+ */
+function resolveWireMessage({
+  message,
+  scope,
+  code,
+}: WireMessageParts): string {
+  if (message) return message;
+  const qualifier = [scope, code].filter(Boolean).join(':');
+  return qualifier ? `[${qualifier}]` : '';
 }
 
 function extractResponseData(
@@ -103,7 +128,11 @@ function extractResponseData(
   if (isVercelError(error)) {
     return {
       error: {
-        message: error.userMessage ?? error.message,
+        message: resolveWireMessage({
+          message: error.userMessage ?? error.message,
+          scope: error.scope,
+          code: error.code,
+        }),
         ...(error.code ? { code: error.code } : {}),
         ...(error.reason ? { reason: error.reason } : {}),
         ...(error.hint ? { hint: error.hint } : {}),
@@ -116,7 +145,7 @@ function extractResponseData(
 
   return {
     error: {
-      message: error.message,
+      message: resolveWireMessage({ message: error.message, code: error.code }),
       ...(error.code ? { code: error.code } : {}),
       ...(error.reason ? { reason: error.reason } : {}),
       ...(error.hint ? { hint: error.hint } : {}),

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,17 +48,46 @@ export interface ErrorLike {
  * Configuration options for creating a VercelError instance.
  */
 export interface VercelErrorOptions<TCode extends string = string> {
+  /** Flat OTel-compatible tags for traces, metrics, and error trackers. */
   attributes?: ErrorAttributes;
+
+  /** The underlying error or value that triggered this one, for chaining. */
   cause?: unknown;
+
+  /**
+   * Stable, machine-readable identifier for this error. Keep it constant even
+   * when you reword the message, so users can search it and docs can link to
+   * it. Pick whatever style fits your registry: semantic names
+   * (`pool_exhausted`), numeric codes (`E1001`), or namespaced numbers
+   * (`B2011`). Numbering is optional, so use words when you prefer them.
+   */
   code?: TCode;
+
+  /** Actionable step that resolves the error, such as a command or config change. */
   fix?: string;
+
+  /** Advisory tip that helps the developer, shown before `fix`. */
   hint?: string;
+
+  /** URL to documentation for this error. Derivable from `code` via `docsBaseUrl`. */
   link?: string;
+
+  /** Nested domain context for debugging and logging. Never sent to clients. */
   metadata?: ErrorMetadata;
+
+  /** Why the error happened, the root-cause explanation behind the message. */
   reason?: string;
+
+  /** Correlation ID for tracing this error across services. */
   requestId?: string;
+
+  /** Namespace that produced the error, such as a service or subsystem. */
   scope?: string;
+
+  /** HTTP status code for the response. Defaults to 500 on the wire. */
   statusCode?: number;
+
+  /** Client-safe message sent over the wire instead of the developer `message`. */
   userMessage?: string;
 
   /** Reserved. Automatically captured from Error */

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,8 @@ export type SerializableValue =
 
 /**
  * Domain-specific structured context for debugging and logging.
- * Can contain arbitrarily nested values. Server-side only — excluded from HTTP error responses.
+ * Can contain arbitrarily nested values. Server-side only, so it is excluded
+ * from HTTP error responses.
  *
  * Route to: serialization, logging, debugging tools.
  *
@@ -60,11 +61,11 @@ export interface VercelErrorOptions<TCode extends string = string> {
   statusCode?: number;
   userMessage?: string;
 
-  /** Reserved — automatically captured from Error */
+  /** Reserved. Automatically captured from Error */
   stack?: never;
-  /** Reserved — pass message as first constructor argument */
+  /** Reserved. Pass message as the first constructor argument */
   message?: never;
-  /** Reserved — hardcoded to "VercelError" for minification safety */
+  /** Reserved. Hardcoded to "VercelError" for minification safety */
   name?: never;
 }
 


### PR DESCRIPTION
## Summary

Moves `createErrors` closer to native JS error ergonomics, lays the groundwork for production stripping of error prose (smaller client bundles), and switches the package to public npm publishing. No catalog API, no change to how you author errors.

This is phases 0-2 of a larger plan. Phase 3 (the unplugin build-time strip transform) lands in a follow-up.

## Changes

### `createErrors` ergonomics
- **`scope` is now optional.** `createErrors()` works with no arguments. Provide a scope only when grouping errors by a namespace is useful. `scope` stays the factory's identity (still not overridable per-error).
- **`docsBaseUrl`** derives each error's `link` from its `code`. A string base appends the code **verbatim** as a path segment (no case transformation); pass a function for custom shaping. An explicit per-error `link` always wins; no `code` means no derivation.

### Production-fallback rendering
A stripped error (empty `message`, only `code`/`scope`/`statusCode`/`link` left) still renders meaningfully:
- **Terminal formatter** falls back to `error: VercelError [scope:code]`, then `[code]`, then just the name.
- **HTTP wire format** folds `[scope:code]` into the required `message` field (the wire format has no `scope`).

### Documentation
- Annotate every option in `VercelErrorOptions`, `ErrorResponseParams`, and `ErrorResponseResult`.
- Document `code` style guidance: semantic names (`pool_exhausted`), numeric codes (`E1001`), or namespaced numbers (`B2011`). Numbering is optional.

### Publishing
- **Publish publicly on npm.** `publishConfig.access` is now `public` and the release workflow runs `npm publish --access public`.
- Removed an unnecessary `npm install -g npm@latest` step from the privileged publish job. The pinned Node 24 already bundles npm >= 11.5.1 (current 11.16.0), which satisfies OIDC Trusted Publishing, so the step only added a mutable, unpinned dependency next to the publish token.

### Housekeeping
- Helpers with 3+ params refactored to a single typed object argument.
- Doc blocks aligned with the Vercel technical writing style (no em dashes for emphasis, active voice).
- Bump to `0.0.2` with changelog.

## Tests

New specs cover no-scope factories, `docsBaseUrl` derivation and precedence (including verbatim code casing), and stripped rendering across both the terminal and HTTP paths. All tests pass; typecheck, lint, and format are clean.

## Notes

No new runtime dependencies. The runtime API is unchanged for existing callers; all additions are optional.