### PR TITLE
feat(unplugin): production error stripping via @vercel/error/unplugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,14 +30,14 @@ src/<fn-name>/index.spec.ts  # Tests
 
 ### Entry Points
 
-| Export              | Source                   | Contents                                               |
-| ------------------- | ------------------------ | ------------------------------------------------------ |
-| `.`                 | `src/index.ts`           | VercelError, createErrors, guards, extractors, types   |
-| `./client`          | `src/client.ts`          | parseErrorResponse                                     |
-| `./server`          | `src/server.ts`          | toErrorResponse, wantsAnsi                             |
-| `./format`          | `src/format.ts`          | frame, fix, link, setDefaultFormatter                  |
-| `./unplugin`        | `src/unplugin/index.ts`  | `vercelErrorStrip` build plugin (prod prose stripping) |
-| `./unplugin/loader` | `src/unplugin/loader.ts` | webpack/Turbopack loader form of the strip transform   |
+| Export              | Source                   | Contents                                             |
+| ------------------- | ------------------------ | ---------------------------------------------------- |
+| `.`                 | `src/index.ts`           | VercelError, createErrors, guards, extractors, types |
+| `./client`          | `src/client.ts`          | parseErrorResponse                                   |
+| `./server`          | `src/server.ts`          | toErrorResponse, wantsAnsi                           |
+| `./format`          | `src/format.ts`          | frame, fix, link, setDefaultFormatter                |
+| `./unplugin`        | `src/unplugin/index.ts`  | `stripErrors` build plugin (prod prose stripping)    |
+| `./unplugin/loader` | `src/unplugin/loader.ts` | webpack/Turbopack loader form of the strip transform |
 
 ### Core Concepts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,12 +30,14 @@ src/<fn-name>/index.spec.ts  # Tests
 
 ### Entry Points
 
-| Export     | Source          | Contents                                             |
-| ---------- | --------------- | ---------------------------------------------------- |
-| `.`        | `src/index.ts`  | VercelError, createErrors, guards, extractors, types |
-| `./client` | `src/client.ts` | parseErrorResponse                                   |
-| `./server` | `src/server.ts` | toErrorResponse, wantsAnsi                           |
-| `./format` | `src/format.ts` | frame, fix, link, setDefaultFormatter                |
+| Export              | Source                   | Contents                                               |
+| ------------------- | ------------------------ | ------------------------------------------------------ |
+| `.`                 | `src/index.ts`           | VercelError, createErrors, guards, extractors, types   |
+| `./client`          | `src/client.ts`          | parseErrorResponse                                     |
+| `./server`          | `src/server.ts`          | toErrorResponse, wantsAnsi                             |
+| `./format`          | `src/format.ts`          | frame, fix, link, setDefaultFormatter                  |
+| `./unplugin`        | `src/unplugin/index.ts`  | `vercelErrorStrip` build plugin (prod prose stripping) |
+| `./unplugin/loader` | `src/unplugin/loader.ts` | webpack/Turbopack loader form of the strip transform   |
 
 ### Core Concepts
 
@@ -43,6 +45,7 @@ src/<fn-name>/index.spec.ts  # Tests
 - **ErrorResponse** — The canonical wire format: `{ error: { code, message, reason?, fix?, link? } }`. Used by all Vercel HTTP error responses.
 - **createErrors** — Factory for scoped error namespaces. Returns `{ create }` or `{ create, raise, report }` depending on whether `report` is provided.
 - **Cross-realm detection** — Uses `Symbol.for('__vercel_error')` instead of `instanceof` for reliable checks across bundle boundaries.
+- **Strip transform** — `@vercel/error/unplugin` removes prose (`message`, `reason`, `hint`, `fix`, `userMessage`) from `new VercelError()` and `createErrors` factory calls in production builds, keeping `code`/`scope`/`statusCode`/`link`. Build deps (`unplugin`, `oxc-parser`, `magic-string`) are **optional peerDependencies**, so the core install stays zero-dep. Never import them from core entry points.
 
 ## Key Design Rules
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ pnpm add @vercel/error
 
 ## Entry points
 
-| Import                 | Purpose                                                        |
-| ---------------------- | -------------------------------------------------------------- |
-| `@vercel/error`        | Core: `VercelError`, `createErrors`, guards, extractors, types |
-| `@vercel/error/server` | Server: `errorResponse`, `wantsAnsi`                           |
-| `@vercel/error/client` | Client: `parseErrorResponse`, `fromErrorResponse`              |
-| `@vercel/error/format` | Format primitives: `frame`, `hint`, `fix`, `link`              |
+| Import                   | Purpose                                                        |
+| ------------------------ | -------------------------------------------------------------- |
+| `@vercel/error`          | Core: `VercelError`, `createErrors`, guards, extractors, types |
+| `@vercel/error/server`   | Server: `errorResponse`, `wantsAnsi`                           |
+| `@vercel/error/client`   | Client: `parseErrorResponse`, `fromErrorResponse`              |
+| `@vercel/error/format`   | Format primitives: `frame`, `hint`, `fix`, `link`              |
+| `@vercel/error/unplugin` | Build plugin: strip error prose from production bundles        |
 
 ## Philosophy
 
@@ -422,3 +423,77 @@ error.name; // 'NetworkError' (stable across minification)
 error.retryable; // true
 error.toString(); // uses NetworkError in the header
 ```
+
+## Production stripping
+
+Error prose (`message`, `reason`, `hint`, `fix`, `userMessage`) is useful in development and on the server, but it adds weight to client bundles. The `@vercel/error/unplugin` build plugin removes that prose from production builds while keeping the structured fields (`code`, `scope`, `statusCode`, `link`). A stripped error still renders as `[scope:code]`, so it stays identifiable.
+
+The plugin rewrites `new VercelError(...)` and `createErrors` factory calls (`.create`, `.raise`, `.report`) whose bindings come from `@vercel/error`. It runs only when `process.env.NODE_ENV` is `production`, so development builds keep full messages. Install the build dependencies (`unplugin`, `oxc-parser`, `magic-string`) alongside the plugin.
+
+### Vite, Rollup, Rolldown, webpack, esbuild, Rspack
+
+Use the matching adapter from the shared plugin.
+
+```ts
+// vite.config.ts
+import { vercelErrorStrip } from '@vercel/error/unplugin';
+
+export default defineConfig({
+  plugins: [vercelErrorStrip.vite()],
+});
+```
+
+The same instance exposes `.rollup()`, `.rolldown()`, `.webpack()`, `.esbuild()`, and `.rspack()`.
+
+### Next.js
+
+For the webpack build, add the plugin in `next.config.js`:
+
+```js
+const { vercelErrorStrip } = require('@vercel/error/unplugin');
+
+module.exports = {
+  webpack(config) {
+    config.plugins.push(vercelErrorStrip.webpack());
+    return config;
+  },
+};
+```
+
+Turbopack does not support unplugin, but it runs webpack loaders. Use the loader form with a production condition:
+
+```js
+// next.config.js
+module.exports = {
+  turbopack: {
+    rules: {
+      '*.{ts,tsx,js,jsx}': {
+        condition: 'production',
+        loaders: ['@vercel/error/unplugin/loader'],
+      },
+    },
+  },
+};
+```
+
+### What survives
+
+```ts
+// Source
+throw new VercelError('Pool exhausted at 10.0.1.5', {
+  code: 'pool_exhausted',
+  scope: 'database',
+  statusCode: 503,
+  reason: 'All 20 connections are in use.',
+  fix: 'Increase max_connections.',
+});
+
+// Production bundle (prose removed, identity kept)
+throw new VercelError('', {
+  code: 'pool_exhausted',
+  scope: 'database',
+  statusCode: 503,
+});
+```
+
+Dynamic option objects (spreads or variables) are left untouched, so anything the plugin cannot statically verify keeps its original prose.

--- a/README.md
+++ b/README.md
@@ -436,10 +436,10 @@ Use the matching adapter from the shared plugin.
 
 ```ts
 // vite.config.ts
-import { vercelErrorStrip } from '@vercel/error/unplugin';
+import { stripErrors } from '@vercel/error/unplugin';
 
 export default defineConfig({
-  plugins: [vercelErrorStrip.vite()],
+  plugins: [stripErrors.vite()],
 });
 ```
 
@@ -450,11 +450,11 @@ The same instance exposes `.rollup()`, `.rolldown()`, `.webpack()`, `.esbuild()`
 For the webpack build, add the plugin in `next.config.js`:
 
 ```js
-const { vercelErrorStrip } = require('@vercel/error/unplugin');
+const { stripErrors } = require('@vercel/error/unplugin');
 
 module.exports = {
   webpack(config) {
-    config.plugins.push(vercelErrorStrip.webpack());
+    config.plugins.push(stripErrors.webpack());
     return config;
   },
 };

--- a/README.md
+++ b/README.md
@@ -428,7 +428,11 @@ error.toString(); // uses NetworkError in the header
 
 Error prose (`message`, `reason`, `hint`, `fix`, `userMessage`) is useful in development and on the server, but it adds weight to client bundles. The `@vercel/error/unplugin` build plugin removes that prose from production builds while keeping the structured fields (`code`, `scope`, `statusCode`, `link`). A stripped error still renders as `[scope:code]`, so it stays identifiable.
 
-The plugin rewrites `new VercelError(...)` and `createErrors` factory calls (`.create`, `.raise`, `.report`) whose bindings come from `@vercel/error`. It runs only when `process.env.NODE_ENV` is `production`, so development builds keep full messages. Install the build dependencies (`unplugin`, `oxc-parser`, `magic-string`) alongside the plugin.
+The plugin rewrites `new VercelError(...)` and `createErrors` factory calls (`.create`, `.raise`, `.report`) whose bindings come from `@vercel/error`. Install the build dependencies (`unplugin`, `oxc-parser`, `magic-string`) alongside the plugin.
+
+Stripping runs only when `process.env.NODE_ENV` is `production`, so development builds keep full messages. Bundlers such as Vite and Next.js set that during a production build. Standalone tools (for example tsdown) may not, so set the env or force it with `enabled: true`.
+
+Strip in the build where the code reaches users. For a frontend app or browser library, strip the app or library build. For a server or agentic library, prefer to keep prose and let the consuming app strip at its own build time, since stripping a published library bakes empty messages into the artifact for every consumer.
 
 ### Vite, Rollup, Rolldown, webpack, esbuild, Rspack
 
@@ -445,6 +449,21 @@ export default defineConfig({
 
 The same instance exposes `.rollup()`, `.rolldown()`, `.webpack()`, `.esbuild()`, and `.rspack()`.
 
+### tsdown
+
+tsdown runs on Rolldown, so use the `.rolldown()` adapter. tsdown does not set `NODE_ENV`, so force the transform on for the published build:
+
+```ts
+// tsdown.config.ts
+import { defineConfig } from 'tsdown';
+import { stripErrors } from '@vercel/error/unplugin';
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  plugins: [stripErrors.rolldown({ enabled: true })],
+});
+```
+
 ### Next.js
 
 For the webpack build, add the plugin in `next.config.js`:
@@ -460,7 +479,7 @@ module.exports = {
 };
 ```
 
-Turbopack does not support unplugin, but it runs webpack loaders. Use the loader form with a production condition:
+Turbopack does not support unplugin, but it runs webpack loaders. Use the loader form, which self-gates on `process.env.NODE_ENV`:
 
 ```js
 // next.config.js
@@ -468,13 +487,14 @@ module.exports = {
   turbopack: {
     rules: {
       '*.{ts,tsx,js,jsx}': {
-        condition: 'production',
         loaders: ['@vercel/error/unplugin/loader'],
       },
     },
   },
 };
 ```
+
+The `condition` rule key (for example `condition: 'production'`) narrows a rule to production builds. It requires Next.js 16 or later; on earlier versions, omit it and rely on the loader's own `NODE_ENV` gate.
 
 ### What survives
 
@@ -496,4 +516,26 @@ throw new VercelError('', {
 });
 ```
 
-Dynamic option objects (spreads or variables) are left untouched, so anything the plugin cannot statically verify keeps its original prose.
+`metadata` and `attributes` are preserved, since they usually hold runtime values rather than static prose.
+
+### Limitations
+
+The plugin only rewrites what it can verify statically. It leaves the following intact:
+
+- **Factory bindings from another module.** A factory used in the same file it was created in is stripped. A factory imported from a shared module is not, because its origin cannot be confirmed locally:
+
+  ```ts
+  // errors.ts
+  export const dbErrors = createErrors({ scope: 'db' });
+
+  // usage.ts — not stripped (imported binding)
+  import { dbErrors } from './errors';
+  dbErrors.raise('boom', { reason: 'r' });
+  ```
+
+  To strip these, create and use the factory in the same module, or call `new VercelError(...)` directly.
+
+- **Dynamic option objects.** Spreads (`{ ...base }`) and non-literal option objects are left untouched.
+- **Non-literal messages.** A message passed as a variable or interpolation keeps its value.
+
+In every case the structured fields still work, so a non-stripped call site is correct, just larger.

--- a/package.json
+++ b/package.json
@@ -27,11 +27,30 @@
   "devDependencies": {
     "@types/node": "25.6.0",
     "lefthook": "2.1.5",
+    "magic-string": "^0.30.21",
+    "oxc-parser": "^0.137.0",
     "oxfmt": "0.44.0",
     "oxlint": "1.59.0",
     "tsdown": "0.21.7",
     "typescript": "6.0.2",
+    "unplugin": "^3.0.0",
     "vitest": "4.1.4"
+  },
+  "peerDependencies": {
+    "magic-string": "^0.30.0",
+    "oxc-parser": "^0.137.0",
+    "unplugin": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "magic-string": {
+      "optional": true
+    },
+    "oxc-parser": {
+      "optional": true
+    },
+    "unplugin": {
+      "optional": true
+    }
   },
   "files": [
     "dist",
@@ -54,6 +73,14 @@
     "./format": {
       "default": "./dist/format.js",
       "types": "./dist/format.d.ts"
+    },
+    "./unplugin": {
+      "default": "./dist/unplugin.js",
+      "types": "./dist/unplugin.d.ts"
+    },
+    "./unplugin/loader": {
+      "default": "./dist/unplugin/loader.js",
+      "types": "./dist/unplugin/loader.d.ts"
     }
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       lefthook:
         specifier: 2.1.5
         version: 2.1.5
+      magic-string:
+        specifier: ^0.30.21
+        version: 0.30.21
+      oxc-parser:
+        specifier: ^0.137.0
+        version: 0.137.0
       oxfmt:
         specifier: 0.44.0
         version: 0.44.0
@@ -22,10 +28,13 @@ importers:
         version: 1.59.0
       tsdown:
         specifier: 0.21.7
-        version: 0.21.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(typescript@6.0.2)
+        version: 0.21.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(typescript@6.0.2)
       typescript:
         specifier: 6.0.2
         version: 6.0.2
+      unplugin:
+        specifier: ^3.0.0
+        version: 3.0.0
       vitest:
         specifier: 4.1.4
         version: 4.1.4(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0))
@@ -53,8 +62,14 @@ packages:
     resolution: {integrity: sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
@@ -62,8 +77,14 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -81,11 +102,147 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-parser/binding-android-arm-eabi@0.137.0':
+    resolution: {integrity: sha512-KDs+0VPdEmasOkpuJHW9V5WCF+cvYdMQv2Jd+aJXt+cxIx12NToRQRbXaRwUEDsZw+/jMk81Ve8ZFbjUkJTOwA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.137.0':
+    resolution: {integrity: sha512-WhALNzfy3x/RfC6bsqX+csavuUY0yHHE7XfgPE5M542uhoBZUUoGTPG+nkMbGoG4+gcfss5s7urMyn5QBHu0sw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.137.0':
+    resolution: {integrity: sha512-bFPr5hgmNMOMoyPTGtdsK4Ug21RovIPojRMgDDhSp1LtCnc/DkLwGONKjgRjszg677RlGnkYSviQ8hHaUPOVYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.137.0':
+    resolution: {integrity: sha512-CL5dMm1asqXIDZHg14FLxj3Mc36w8PI7xCWh1uA4is6z8g2XrIILoTcQYOxDbwzuk34RDPX5IAGUxZr6LA9KAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.137.0':
+    resolution: {integrity: sha512-79h8rYGnSlKPGWo7mHr2ixO6ea7aW8B0CT965SZ8SLbNnCOH5aOYBTeVXUY6eMvEaiLyWr8Skuiugr5pDYgLGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.137.0':
+    resolution: {integrity: sha512-ASgmlSimhGyr0lksgVIo6hibz1obnDq4qJbiMX/AzltfgPnanRrzG1Q+23g8ljOHOjv6dsznkUuCYL3gg0sY1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.137.0':
+    resolution: {integrity: sha512-AU2J9aa22Sx32wRGnDjybOU9TQXXQUud5sdUi+ZB0XxwM8aToWLweV+yA0wlQm0yIUVqljquqoHCYEq9II8gJQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.137.0':
+    resolution: {integrity: sha512-GdEtiG89yMr7XkUGxifgodXEEm2f+xW2f9CpDjlgAnBOwhTmrpQMvhOGobLVKUyzf/qHBXW16smk5zbF3nZU6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.137.0':
+    resolution: {integrity: sha512-EGJ+Bs8iXx8KBH8DQ5BLoEm5lnHaYjlh4/8j8vFhrr/6z4tqONy5BZDzLpKmmNWlN6Hlc5r8YOuBVHqZ9vRFEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.137.0':
+    resolution: {integrity: sha512-vzFUQENy/fnbSe5DZWovq6tIBc1uhuMztanSW6rz1e9WdQE4gHwYuD7ZII6JnrJifd1R3RSoqiZbgRFlVL2tYQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.137.0':
+    resolution: {integrity: sha512-SfVI14HBQs9gtLcUD5hTt5hsNbdrqSUNg9S8muN+LhVQ5nf1WwH3hAoK6B9NKgdYgWAQSXFXGiiBedQ4r/BKuw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.137.0':
+    resolution: {integrity: sha512-e7Ppy4FCIFNQxT/ikSeIWFoQ0l+N9vgtRBtLcyZXeolTzApyVoPqEXsYPrcdM/9i0Bwk8knvYd37vaEMxHyi6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.137.0':
+    resolution: {integrity: sha512-Bho5qFwdhqsIFR7gipYEUlqvi3SRrY8sugxXig380MIaakBB1PyU9+7dBiBVScfImTNWhijUxdBwqrprGdq5WA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.137.0':
+    resolution: {integrity: sha512-36mGWtg7PyFzjJwGDkH6/F4o2nIDEoKXLPr/X/lwqklkomQwJJt1I5GJVmGhovUEmgPK5WAeAZMqlFCehwiy9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.137.0':
+    resolution: {integrity: sha512-/Jqx6+N7A44n2BdvUr7pXhVr2vFjs6WGH3unZRczwrfiH0H1zY0QwKQMG/dtRiTlKGDKGukznPT8lx84/oEsZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.137.0':
+    resolution: {integrity: sha512-9Uj0qHNNl+OgT1UTGwF7ixIXU6T1u2SbMidmgPy/h1h/fl2gRS6YpAxxY1gwHofcWjoTwkoMFd8xs5Vuj6GOFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.137.0':
+    resolution: {integrity: sha512-gW2vfkytNGgMVADiuzdvOfw0mWG9za20F/1fCJsif5aBMAvWJTSbpIXbIe0XkOe0VENk+PadpQ7cZgUy2sUJcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.137.0':
+    resolution: {integrity: sha512-x+pFANF0yL5uK/6T7lu6SlR5qid6sp//eZXKLq5iNsIE+EQg6EaS8/wsW7E91nXXjpnPhSoMOHXShSVhGRdn8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.137.0':
+    resolution: {integrity: sha512-sQUqym80PFi6McRsIqfJrSu2JrSClEZIXXD+/FjAFoULEKzOPsldIdFBG96xdX8aVMzCNQ9792FPx3MfkEIrFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.137.0':
+    resolution: {integrity: sha512-2AsevxlvNN4WKxpEn3RtqD5zbqMaXF+T7JXblsP4gVuY+vC9dXS4ED/PwfRCliFqoeisYS3Iro4DHzxr0TEvVA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
 
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
+
+  '@oxc-project/types@0.137.0':
+    resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
 
   '@oxfmt/binding-android-arm-eabi@0.44.0':
     resolution: {integrity: sha512-5UvghMd9SA/yvKTWCAxMAPXS1d2i054UeOf4iFjZjfayTwCINcC3oaSXjtbZfCaEpxgJod7XiOjTtby5yEv/BQ==}
@@ -536,6 +693,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -804,6 +964,10 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  oxc-parser@0.137.0:
+    resolution: {integrity: sha512-yFImD+WLElJpLKy8llG1qe4DCmMsL18peRp8XP1JKfig/gISbJkglnpDtX2aTmAn10kZF7164HbN2H8QPsXxGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   oxfmt@0.44.0:
     resolution: {integrity: sha512-lnncqvHewyRvaqdrnntVIrZV2tEddz8lbvPsQzG/zlkfvgZkwy0HP1p/2u1aCDToeg1jb9zBpbJdfkV73Itw+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -951,6 +1115,10 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
+  unplugin@3.0.0:
+    resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   unrun@0.2.35:
     resolution: {integrity: sha512-nDP7mA4Fu5owDarQtLiiN3lq7tJZHFEAVIchnwP8U3wMeEkLoUNT37Hva85H05Rdw8CArpGmtY+lBjpk9fruVQ==}
     engines: {node: '>=20.19.0'}
@@ -1045,6 +1213,9 @@ packages:
       jsdom:
         optional: true
 
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -1074,9 +1245,20 @@ snapshots:
       '@babel/helper-string-parser': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.9.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -1090,9 +1272,19 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -1104,6 +1296,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
       '@emnapi/core': 1.9.2
@@ -1111,9 +1310,82 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@oxc-parser/binding-android-arm-eabi@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.137.0':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.137.0':
+    optional: true
+
   '@oxc-project/types@0.122.0': {}
 
   '@oxc-project/types@0.124.0': {}
+
+  '@oxc-project/types@0.137.0': {}
 
   '@oxfmt/binding-android-arm-eabi@0.44.0':
     optional: true
@@ -1305,9 +1577,9 @@ snapshots:
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -1339,6 +1611,11 @@ snapshots:
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -1550,6 +1827,31 @@ snapshots:
 
   obug@2.1.1: {}
 
+  oxc-parser@0.137.0:
+    dependencies:
+      '@oxc-project/types': 0.137.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.137.0
+      '@oxc-parser/binding-android-arm64': 0.137.0
+      '@oxc-parser/binding-darwin-arm64': 0.137.0
+      '@oxc-parser/binding-darwin-x64': 0.137.0
+      '@oxc-parser/binding-freebsd-x64': 0.137.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.137.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.137.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.137.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.137.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.137.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.137.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.137.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.137.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.137.0
+      '@oxc-parser/binding-linux-x64-musl': 0.137.0
+      '@oxc-parser/binding-openharmony-arm64': 0.137.0
+      '@oxc-parser/binding-wasm32-wasi': 0.137.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.137.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.137.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.137.0
+
   oxfmt@0.44.0:
     dependencies:
       tinypool: 2.1.0
@@ -1612,7 +1914,7 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.2):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(typescript@6.0.2):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3
@@ -1624,13 +1926,13 @@ snapshots:
       get-tsconfig: 4.13.7
       obug: 2.1.1
       picomatch: 4.0.4
-      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optionalDependencies:
       typescript: 6.0.2
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+  rolldown@1.0.0-rc.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     dependencies:
       '@oxc-project/types': 0.122.0
       '@rolldown/pluginutils': 1.0.0-rc.12
@@ -1647,7 +1949,7 @@ snapshots:
       '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
       '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
       '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
     transitivePeerDependencies:
@@ -1700,7 +2002,7 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  tsdown@0.21.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(typescript@6.0.2):
+  tsdown@0.21.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(typescript@6.0.2):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -1710,8 +2012,8 @@ snapshots:
       import-without-cache: 0.2.5
       obug: 2.1.1
       picomatch: 4.0.4
-      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.2)
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(typescript@6.0.2)
       semver: 7.7.4
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
@@ -1740,6 +2042,12 @@ snapshots:
       quansync: 1.0.0
 
   undici-types@7.19.2: {}
+
+  unplugin@3.0.0:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
 
   unrun@0.2.35:
     dependencies:
@@ -1782,6 +2090,8 @@ snapshots:
       '@types/node': 25.6.0
     transitivePeerDependencies:
       - msw
+
+  webpack-virtual-modules@0.6.2: {}
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/src/unplugin/index.ts
+++ b/src/unplugin/index.ts
@@ -8,8 +8,8 @@ import { transform } from './transform';
 export interface StripErrorsOptions {
   /**
    * Force the transform on or off regardless of the detected build mode. When
-   * omitted, the transform runs only for production builds (resolved from the
-   * bundler's mode or `process.env.NODE_ENV`).
+   * omitted, the transform runs only when `process.env.NODE_ENV` is
+   * `production`.
    */
   enabled?: boolean;
 
@@ -18,9 +18,22 @@ export interface StripErrorsOptions {
    * Applied on top of the built-in extension filter.
    */
   include?: (id: string) => boolean;
+
+  /**
+   * Transform files inside `node_modules`. Defaults to `false`, since apps
+   * usually strip their own source rather than prebuilt dependencies.
+   */
+  includeNodeModules?: boolean;
+
+  /**
+   * Log a one-line summary of how many call sites were stripped, per module.
+   * Useful for confirming the plugin is active. Defaults to `false`.
+   */
+  verbose?: boolean;
 }
 
 const DEFAULT_EXTENSIONS = /\.(?:[cm]?[jt]sx?)$/;
+const NODE_MODULES = /[/\\]node_modules[/\\]/;
 
 /**
  * Build-time plugin that strips human-readable error prose from
@@ -53,11 +66,19 @@ export const stripErrors: UnpluginInstance<StripErrorsOptions | undefined> =
       enforce: 'pre',
       transformInclude(id) {
         if (!DEFAULT_EXTENSIONS.test(id)) return false;
+        if (!options?.includeNodeModules && NODE_MODULES.test(id)) return false;
         return options?.include ? options.include(id) : true;
       },
       transform(code, id) {
         if (!active) return null;
-        return transform(code, id);
+        const result = transform(code, id);
+        if (result && options?.verbose) {
+          // eslint-disable-next-line no-console -- opt-in build diagnostics
+          console.info(
+            `[@vercel/error/strip] stripped ${result.count} call site(s) in ${id}`,
+          );
+        }
+        return result;
       },
     };
   });

--- a/src/unplugin/index.ts
+++ b/src/unplugin/index.ts
@@ -1,0 +1,68 @@
+import { createUnplugin, type UnpluginInstance } from 'unplugin';
+
+import { transform } from './transform';
+
+/**
+ * Options for the `@vercel/error` strip plugin.
+ */
+export interface VercelErrorStripOptions {
+  /**
+   * Force the transform on or off regardless of the detected build mode. When
+   * omitted, the transform runs only for production builds (resolved from the
+   * bundler's mode or `process.env.NODE_ENV`).
+   */
+  enabled?: boolean;
+
+  /**
+   * Extra module filter. Receives the module id and returns `false` to skip it.
+   * Applied on top of the built-in extension filter.
+   */
+  include?: (id: string) => boolean;
+}
+
+const DEFAULT_EXTENSIONS = /\.(?:[cm]?[jt]sx?)$/;
+
+/**
+ * Build-time plugin that strips human-readable error prose from
+ * `@vercel/error` call sites in production builds, shrinking client bundles.
+ *
+ * Removes the message argument and the `reason`, `hint`, `fix`, and
+ * `userMessage` options from `new VercelError(...)` and `createErrors` factory
+ * calls. Keeps `code`, `scope`, `statusCode`, and `link` so a stripped error
+ * still identifies itself by `[scope:code]`.
+ *
+ * Works with Vite, Rollup, Rolldown, webpack, esbuild, and Rspack through the
+ * matching adapter (`.vite()`, `.webpack()`, and so on).
+ *
+ * @example
+ * ```ts
+ * // vite.config.ts
+ * import { vercelErrorStrip } from '@vercel/error/unplugin';
+ *
+ * export default defineConfig({
+ *   plugins: [vercelErrorStrip.vite()],
+ * });
+ * ```
+ */
+export const vercelErrorStrip: UnpluginInstance<
+  VercelErrorStripOptions | undefined
+> = createUnplugin((options?: VercelErrorStripOptions) => {
+  const active = options?.enabled ?? getNodeEnv() === 'production';
+
+  return {
+    name: '@vercel/error/strip',
+    enforce: 'pre',
+    transformInclude(id) {
+      if (!DEFAULT_EXTENSIONS.test(id)) return false;
+      return options?.include ? options.include(id) : true;
+    },
+    transform(code, id) {
+      if (!active) return null;
+      return transform(code, id);
+    },
+  };
+});
+
+function getNodeEnv(): string | undefined {
+  return typeof process !== 'undefined' ? process.env?.['NODE_ENV'] : undefined;
+}

--- a/src/unplugin/index.ts
+++ b/src/unplugin/index.ts
@@ -5,7 +5,7 @@ import { transform } from './transform';
 /**
  * Options for the `@vercel/error` strip plugin.
  */
-export interface VercelErrorStripOptions {
+export interface StripErrorsOptions {
   /**
    * Force the transform on or off regardless of the detected build mode. When
    * omitted, the transform runs only for production builds (resolved from the
@@ -37,31 +37,30 @@ const DEFAULT_EXTENSIONS = /\.(?:[cm]?[jt]sx?)$/;
  * @example
  * ```ts
  * // vite.config.ts
- * import { vercelErrorStrip } from '@vercel/error/unplugin';
+ * import { stripErrors } from '@vercel/error/unplugin';
  *
  * export default defineConfig({
- *   plugins: [vercelErrorStrip.vite()],
+ *   plugins: [stripErrors.vite()],
  * });
  * ```
  */
-export const vercelErrorStrip: UnpluginInstance<
-  VercelErrorStripOptions | undefined
-> = createUnplugin((options?: VercelErrorStripOptions) => {
-  const active = options?.enabled ?? getNodeEnv() === 'production';
+export const stripErrors: UnpluginInstance<StripErrorsOptions | undefined> =
+  createUnplugin((options?: StripErrorsOptions) => {
+    const active = options?.enabled ?? getNodeEnv() === 'production';
 
-  return {
-    name: '@vercel/error/strip',
-    enforce: 'pre',
-    transformInclude(id) {
-      if (!DEFAULT_EXTENSIONS.test(id)) return false;
-      return options?.include ? options.include(id) : true;
-    },
-    transform(code, id) {
-      if (!active) return null;
-      return transform(code, id);
-    },
-  };
-});
+    return {
+      name: '@vercel/error/strip',
+      enforce: 'pre',
+      transformInclude(id) {
+        if (!DEFAULT_EXTENSIONS.test(id)) return false;
+        return options?.include ? options.include(id) : true;
+      },
+      transform(code, id) {
+        if (!active) return null;
+        return transform(code, id);
+      },
+    };
+  });
 
 function getNodeEnv(): string | undefined {
   return typeof process !== 'undefined' ? process.env?.['NODE_ENV'] : undefined;

--- a/src/unplugin/loader.ts
+++ b/src/unplugin/loader.ts
@@ -19,6 +19,12 @@ export interface StripLoaderOptions {
    * `process.env.NODE_ENV === 'production'`.
    */
   enabled?: boolean;
+
+  /**
+   * Log a one-line summary of how many call sites were stripped, per module.
+   * Useful for confirming the loader is active. Defaults to `false`.
+   */
+  verbose?: boolean;
 }
 
 /**
@@ -58,6 +64,12 @@ function stripErrorsLoader(this: LoaderContext, source: string): void {
   try {
     const result = transform(source, this.resourcePath);
     if (result) {
+      if (options.verbose) {
+        // eslint-disable-next-line no-console -- opt-in build diagnostics
+        console.info(
+          `[@vercel/error/strip] stripped ${result.count} call site(s) in ${this.resourcePath}`,
+        );
+      }
       callback(null, result.code, result.map as object);
     } else {
       callback(null, source);

--- a/src/unplugin/loader.ts
+++ b/src/unplugin/loader.ts
@@ -1,0 +1,70 @@
+import { transform } from './transform';
+
+/**
+ * Minimal webpack loader context used by this loader. Matches both webpack and
+ * Turbopack's `loader-runner` implementation.
+ */
+interface LoaderContext {
+  resourcePath: string;
+  async(): (error: Error | null, content?: string, sourceMap?: object) => void;
+  getOptions?: () => StripLoaderOptions | undefined;
+}
+
+/**
+ * Options accepted via `turbopackLoaderOptions` (or webpack loader options).
+ */
+export interface StripLoaderOptions {
+  /**
+   * Force the transform on or off. When omitted, the loader strips only when
+   * `process.env.NODE_ENV === 'production'`.
+   */
+  enabled?: boolean;
+}
+
+/**
+ * Webpack-compatible loader that strips `@vercel/error` prose for production.
+ *
+ * Use this with Next.js Turbopack, which runs webpack loaders but does not
+ * support unplugin. Restrict it to production with a rule condition.
+ *
+ * @example
+ * ```js
+ * // next.config.js
+ * module.exports = {
+ *   turbopack: {
+ *     rules: {
+ *       '*.{ts,tsx,js,jsx}': {
+ *         condition: 'production',
+ *         loaders: ['@vercel/error/unplugin/loader'],
+ *       },
+ *     },
+ *   },
+ * };
+ * ```
+ */
+function vercelErrorStripLoader(this: LoaderContext, source: string): void {
+  const callback = this.async();
+  const options = this.getOptions?.() ?? {};
+  const active =
+    options.enabled ??
+    (typeof process !== 'undefined' &&
+      process.env?.['NODE_ENV'] === 'production');
+
+  if (!active) {
+    callback(null, source);
+    return;
+  }
+
+  try {
+    const result = transform(source, this.resourcePath);
+    if (result) {
+      callback(null, result.code, result.map as object);
+    } else {
+      callback(null, source);
+    }
+  } catch (error) {
+    callback(error as Error);
+  }
+}
+
+export default vercelErrorStripLoader;

--- a/src/unplugin/loader.ts
+++ b/src/unplugin/loader.ts
@@ -42,7 +42,7 @@ export interface StripLoaderOptions {
  * };
  * ```
  */
-function vercelErrorStripLoader(this: LoaderContext, source: string): void {
+function stripErrorsLoader(this: LoaderContext, source: string): void {
   const callback = this.async();
   const options = this.getOptions?.() ?? {};
   const active =
@@ -67,4 +67,4 @@ function vercelErrorStripLoader(this: LoaderContext, source: string): void {
   }
 }
 
-export default vercelErrorStripLoader;
+export default stripErrorsLoader;

--- a/src/unplugin/transform/index.spec.ts
+++ b/src/unplugin/transform/index.spec.ts
@@ -82,6 +82,31 @@ describe('transform: new VercelError', () => {
     expect(out).not.toMatch(/reason|hint|fix/);
     expect(out).not.toContain(',,');
   });
+
+  it('produces valid JS for adjacent prose props', () => {
+    const out = expectValid(
+      run(
+        `import { VercelError } from '@vercel/error';\n` +
+          // adjacent prose, last is prose
+          `new VercelError('a', { code: 'x', reason: 'r', hint: 'h' });\n` +
+          // all prose then structured
+          `new VercelError('b', { reason: 'r', hint: 'h', fix: 'f', code: 'x' });`,
+      ),
+    );
+    expect(out).not.toMatch(/reason|hint|fix/);
+    expect(out).toMatch(/code: 'x'/);
+  });
+
+  it('handles a trailing comma after the last prose prop', () => {
+    const out = expectValid(
+      run(
+        `import { VercelError } from '@vercel/error';\n` +
+          `new VercelError('a', { code: 'x', reason: 'r', });`,
+      ),
+    );
+    expect(out).not.toContain('reason');
+    expect(out).toContain("code: 'x'");
+  });
 });
 
 describe('transform: createErrors factory', () => {
@@ -147,5 +172,18 @@ describe('transform: safety', () => {
           `other.raise('keep me');`,
       ),
     ).toBeNull();
+  });
+});
+
+describe('transform: count', () => {
+  it('reports the number of stripped call sites', () => {
+    const result = transform(
+      `import { VercelError, createErrors } from '@vercel/error';\n` +
+        `const errors = createErrors({ scope: 'db' });\n` +
+        `new VercelError('a', { code: 'x' });\n` +
+        `errors.raise('b', { code: 'y' });`,
+      'test.ts',
+    );
+    expect(result?.count).toBe(2);
   });
 });

--- a/src/unplugin/transform/index.spec.ts
+++ b/src/unplugin/transform/index.spec.ts
@@ -1,0 +1,151 @@
+import { parseSync } from 'oxc-parser';
+import { describe, expect, it } from 'vitest';
+
+import { transform } from '.';
+
+function run(code: string): string | null {
+  const result = transform(code, 'test.ts');
+  return result ? result.code : null;
+}
+
+/** Assert the output parses cleanly (no dangling commas or broken objects). */
+function expectValid(code: string | null): string {
+  expect(code).not.toBeNull();
+  const { errors } = parseSync('out.ts', code as string);
+  expect(errors).toEqual([]);
+  return code as string;
+}
+
+describe('transform: new VercelError', () => {
+  it('blanks the message argument', () => {
+    const out = run(
+      `import { VercelError } from '@vercel/error';\n` +
+        `throw new VercelError('Connection failed', { code: 'conn_failed' });`,
+    );
+    expect(out).toContain("new VercelError(''");
+    expect(out).not.toContain('Connection failed');
+    expect(out).toContain("code: 'conn_failed'");
+  });
+
+  it('removes prose props but keeps structured fields', () => {
+    const out = run(
+      `import { VercelError } from '@vercel/error';\n` +
+        `new VercelError('boom', {\n` +
+        `  code: 'x',\n` +
+        `  scope: 'db',\n` +
+        `  statusCode: 503,\n` +
+        `  link: 'https://e.dev/x',\n` +
+        `  reason: 'why it broke',\n` +
+        `  hint: 'try this',\n` +
+        `  fix: 'do that',\n` +
+        `  userMessage: 'safe message',\n` +
+        `});`,
+    );
+    expect(out).not.toContain('why it broke');
+    expect(out).not.toContain('try this');
+    expect(out).not.toContain('do that');
+    expect(out).not.toContain('safe message');
+    expect(out).toContain("code: 'x'");
+    expect(out).toContain("scope: 'db'");
+    expect(out).toContain('statusCode: 503');
+    expect(out).toContain("link: 'https://e.dev/x'");
+  });
+
+  it('handles aliased imports', () => {
+    const out = run(
+      `import { VercelError as VE } from '@vercel/error';\n` +
+        `new VE('secret', { code: 'x', reason: 'r' });`,
+    );
+    expect(out).not.toContain('secret');
+    expect(out).not.toContain('reason');
+    expect(out).toContain("code: 'x'");
+  });
+
+  it('strips a blank object cleanly when only prose is present', () => {
+    const out = run(
+      `import { VercelError } from '@vercel/error';\n` +
+        `new VercelError('msg', { reason: 'r' });`,
+    );
+    expect(out).not.toContain('reason');
+    expect(out).not.toContain("'r'");
+  });
+
+  it('produces valid JS for mixed prop positions (first, middle, last)', () => {
+    const out = expectValid(
+      run(
+        `import { VercelError } from '@vercel/error';\n` +
+          `new VercelError('a', { reason: 'r', code: 'x', scope: 'db' });\n` +
+          `new VercelError('b', { code: 'x', hint: 'h', scope: 'db' });\n` +
+          `new VercelError('c', { code: 'x', scope: 'db', fix: 'f' });`,
+      ),
+    );
+    expect(out).not.toMatch(/reason|hint|fix/);
+    expect(out).not.toContain(',,');
+  });
+});
+
+describe('transform: createErrors factory', () => {
+  it('strips raise/create/report calls on a tracked factory', () => {
+    const out = run(
+      `import { createErrors } from '@vercel/error';\n` +
+        `const errors = createErrors({ scope: 'db' });\n` +
+        `errors.raise('Timeout', { code: 'timeout', hint: 'wait' });\n` +
+        `errors.create('Other', { code: 'other', fix: 'retry' });`,
+    );
+    expect(out).not.toContain('Timeout');
+    expect(out).not.toContain('wait');
+    expect(out).not.toContain('Other');
+    expect(out).not.toContain('retry');
+    expect(out).toContain("code: 'timeout'");
+    expect(out).toContain("code: 'other'");
+  });
+});
+
+describe('transform: safety', () => {
+  it('returns null when the package is not imported', () => {
+    expect(
+      run(`class VercelError {}\nnew VercelError('keep me', {});`),
+    ).toBeNull();
+  });
+
+  it('ignores a VercelError-named symbol from another module', () => {
+    expect(
+      run(
+        `import { VercelError } from 'somewhere-else';\n` +
+          `new VercelError('keep me', { reason: 'keep' });`,
+      ),
+    ).toBeNull();
+  });
+
+  it('leaves spread option objects intact', () => {
+    const code =
+      `import { VercelError } from '@vercel/error';\n` +
+      `const base = { reason: 'r' };\n` +
+      `new VercelError('msg', { ...base, code: 'x' });`;
+    const out = run(code);
+    // message is still blanked, but the spread object is untouched
+    expect(out).toContain('...base');
+    expect(out).toContain('reason'); // inside base, not removed
+  });
+
+  it('leaves a dynamic (non-literal) message intact', () => {
+    const out = run(
+      `import { VercelError } from '@vercel/error';\n` +
+        `const m = 'x';\n` +
+        `new VercelError(m, { code: 'x', reason: 'r' });`,
+    );
+    // message variable preserved, but prose prop still removed
+    expect(out).toContain('new VercelError(m,');
+    expect(out).not.toContain("reason: 'r'");
+  });
+
+  it('does not strip factory calls on untracked objects', () => {
+    expect(
+      run(
+        `import { createErrors } from '@vercel/error';\n` +
+          `const other = { raise: (m) => m };\n` +
+          `other.raise('keep me');`,
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/unplugin/transform/index.ts
+++ b/src/unplugin/transform/index.ts
@@ -1,0 +1,260 @@
+import MagicString from 'magic-string';
+import { parseSync } from 'oxc-parser';
+
+/**
+ * Module specifier the `VercelError` class and `createErrors` factory must be
+ * imported from for a call site to be eligible for stripping.
+ */
+const PACKAGE_NAME = '@vercel/error';
+
+/**
+ * Prose option properties removed from production builds. These hold
+ * human-readable text that bloats client bundles. Structured fields
+ * (`code`, `scope`, `statusCode`, `link`) are preserved.
+ */
+const PROSE_PROPS = new Set(['reason', 'hint', 'fix', 'userMessage']);
+
+/**
+ * Factory methods exposed by `createErrors`. Calls to these on a tracked
+ * factory binding are stripped like a direct `new VercelError(...)`.
+ */
+const FACTORY_METHODS = new Set(['create', 'raise', 'report']);
+
+/**
+ * Result of {@link transform}: the rewritten code and a source map, or `null`
+ * when nothing was changed.
+ */
+export interface TransformResult {
+  code: string;
+  map: ReturnType<MagicString['generateMap']>;
+}
+
+/**
+ * Strip human-readable prose from `@vercel/error` call sites for production
+ * builds. Removes the `message` argument and the `reason`, `hint`, `fix`, and
+ * `userMessage` options from `new VercelError(...)` and from `createErrors`
+ * factory calls (`.create`/`.raise`/`.report`). Preserves `code`, `scope`,
+ * `statusCode`, and `link` so a stripped error still identifies itself.
+ *
+ * Only call sites bound to imports from `@vercel/error` are touched. Dynamic
+ * option objects (spreads, variables) are left intact. Returns `null` when the
+ * source has no eligible call sites or no changes were made.
+ */
+export function transform(code: string, id: string): TransformResult | null {
+  // Cheap bailout: skip files that never reference the package.
+  if (!code.includes(PACKAGE_NAME)) return null;
+
+  const { program, errors } = parseSync(id, code);
+  if (errors.length > 0) return null;
+
+  const bindings = collectBindings(program);
+  if (!bindings.errorClasses.size && !bindings.factories.size) return null;
+
+  const magic = new MagicString(code);
+  let changed = false;
+
+  walk(program, (node) => {
+    if (isStrippableNew(node, bindings.errorClasses)) {
+      changed = stripCall(magic, node) || changed;
+    } else if (isStrippableFactoryCall(node, bindings.factories)) {
+      changed = stripCall(magic, node) || changed;
+    }
+  });
+
+  if (!changed) return null;
+
+  return {
+    code: magic.toString(),
+    map: magic.generateMap({ source: id, hires: true }),
+  };
+}
+
+interface Bindings {
+  /** Local names bound to the `VercelError` import. */
+  errorClasses: Set<string>;
+  /** Local names of variables assigned from `createErrors(...)`. */
+  factories: Set<string>;
+}
+
+/**
+ * Collect local identifiers bound to `VercelError` and to `createErrors`
+ * results. Handles named and aliased imports from `@vercel/error`. Namespace
+ * imports are intentionally ignored, since member access cannot be resolved
+ * statically with confidence.
+ */
+function collectBindings(program: AnyNode): Bindings {
+  const errorClasses = new Set<string>();
+  const factories = new Set<string>();
+  const createErrorsNames = new Set<string>();
+
+  for (const node of program.body ?? []) {
+    if (
+      node.type !== 'ImportDeclaration' ||
+      node.source?.value !== PACKAGE_NAME
+    ) {
+      continue;
+    }
+    for (const spec of node.specifiers ?? []) {
+      if (spec.type !== 'ImportSpecifier') continue;
+      const imported = spec.imported?.name;
+      const local = spec.local?.name;
+      if (!imported || !local) continue;
+      if (imported === 'VercelError') errorClasses.add(local);
+      if (imported === 'createErrors') createErrorsNames.add(local);
+    }
+  }
+
+  if (createErrorsNames.size > 0) {
+    walk(program, (node) => {
+      if (node.type !== 'VariableDeclarator') return;
+      const init = node.init;
+      if (
+        init?.type === 'CallExpression' &&
+        init.callee?.type === 'Identifier' &&
+        createErrorsNames.has(init.callee.name) &&
+        node.id?.type === 'Identifier'
+      ) {
+        factories.add(node.id.name);
+      }
+    });
+  }
+
+  return { errorClasses, factories };
+}
+
+/** `new VercelError(...)` where the callee is a tracked error class binding. */
+function isStrippableNew(node: AnyNode, errorClasses: Set<string>): boolean {
+  return (
+    node.type === 'NewExpression' &&
+    node.callee?.type === 'Identifier' &&
+    errorClasses.has(node.callee.name)
+  );
+}
+
+/** `factory.create|raise|report(...)` where `factory` is a tracked binding. */
+function isStrippableFactoryCall(
+  node: AnyNode,
+  factories: Set<string>,
+): boolean {
+  if (node.type !== 'CallExpression') return false;
+  const callee = node.callee;
+  return (
+    callee?.type === 'MemberExpression' &&
+    callee.object?.type === 'Identifier' &&
+    factories.has(callee.object.name) &&
+    callee.property?.type === 'Identifier' &&
+    FACTORY_METHODS.has(callee.property.name)
+  );
+}
+
+/**
+ * Blank the message argument and remove prose properties from the options
+ * object of a call. Returns whether any edit was made.
+ */
+function stripCall(magic: MagicString, node: AnyNode): boolean {
+  const args = node.arguments ?? [];
+  if (args.length === 0) return false;
+
+  let changed = false;
+
+  const message = args[0];
+  if (isStringLiteralLike(message)) {
+    magic.overwrite(message.start, message.end, "''");
+    changed = true;
+  }
+
+  const options = args[1];
+  if (options?.type === 'ObjectExpression') {
+    changed = stripProseProps(magic, options) || changed;
+  }
+
+  return changed;
+}
+
+/**
+ * Remove prose properties from an options object literal. Skips objects that
+ * contain spreads, since their final shape is not statically known. Each
+ * removed property also consumes one adjacent comma so the object stays valid.
+ */
+function stripProseProps(magic: MagicString, object: AnyNode): boolean {
+  const props = (object.properties ?? []) as AnyNode[];
+  if (props.some((p) => p.type === 'SpreadElement')) return false;
+
+  let changed = false;
+  for (let i = 0; i < props.length; i++) {
+    const prop = props[i];
+    if (
+      !prop ||
+      prop.type !== 'Property' ||
+      prop.key?.type !== 'Identifier' ||
+      !PROSE_PROPS.has(prop.key.name)
+    ) {
+      continue;
+    }
+
+    const next = props[i + 1];
+    const prev = props[i - 1];
+    const start = next
+      ? prop.start // not last: drop the trailing comma by ending at next prop
+      : prev
+        ? prev.end // last with a sibling: drop the preceding comma
+        : prop.start; // sole property: remove just the property
+    const end = next ? next.start : prop.end;
+
+    magic.remove(start, end);
+    changed = true;
+  }
+  return changed;
+}
+
+function isStringLiteralLike(node: AnyNode | undefined): boolean {
+  if (!node) return false;
+  if (node.type === 'Literal') return typeof node.value === 'string';
+  // Template literal with no expressions is a static string.
+  return (
+    node.type === 'TemplateLiteral' && (node.expressions ?? []).length === 0
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Minimal AST walk
+// ---------------------------------------------------------------------------
+
+/**
+ * Loosely typed AST node. The oxc AST is ESTree-compatible; this transform
+ * only reads a small, well-known subset of fields. Properties are typed as
+ * `any` because the walk traverses arbitrary node shapes.
+ */
+interface AnyNode {
+  type: string;
+  start: number;
+  end: number;
+  // eslint-disable-next-line ts/no-explicit-any -- AST traversal reads arbitrary node fields
+  [key: string]: any;
+}
+
+/**
+ * Depth-first walk over every node in the tree, invoking `visit` on each.
+ */
+function walk(node: AnyNode, visit: (node: AnyNode) => void): void {
+  visit(node);
+  for (const key in node) {
+    if (key === 'type' || key === 'start' || key === 'end') continue;
+    const value = node[key];
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        if (isNode(child)) walk(child, visit);
+      }
+    } else if (isNode(value)) {
+      walk(value, visit);
+    }
+  }
+}
+
+function isNode(value: unknown): value is AnyNode {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { type?: unknown }).type === 'string'
+  );
+}

--- a/src/unplugin/transform/index.ts
+++ b/src/unplugin/transform/index.ts
@@ -21,12 +21,14 @@ const PROSE_PROPS = new Set(['reason', 'hint', 'fix', 'userMessage']);
 const FACTORY_METHODS = new Set(['create', 'raise', 'report']);
 
 /**
- * Result of {@link transform}: the rewritten code and a source map, or `null`
- * when nothing was changed.
+ * Result of {@link transform}: the rewritten code, a source map, and the
+ * number of call sites that were stripped. `null` when nothing changed.
  */
 export interface TransformResult {
   code: string;
   map: ReturnType<MagicString['generateMap']>;
+  /** Count of `new VercelError`/factory call sites rewritten in this module. */
+  count: number;
 }
 
 /**
@@ -51,21 +53,23 @@ export function transform(code: string, id: string): TransformResult | null {
   if (!bindings.errorClasses.size && !bindings.factories.size) return null;
 
   const magic = new MagicString(code);
-  let changed = false;
+  let count = 0;
 
   walk(program, (node) => {
-    if (isStrippableNew(node, bindings.errorClasses)) {
-      changed = stripCall(magic, node) || changed;
-    } else if (isStrippableFactoryCall(node, bindings.factories)) {
-      changed = stripCall(magic, node) || changed;
+    if (
+      isStrippableNew(node, bindings.errorClasses) ||
+      isStrippableFactoryCall(node, bindings.factories)
+    ) {
+      if (stripCall(magic, code, node)) count++;
     }
   });
 
-  if (!changed) return null;
+  if (count === 0) return null;
 
   return {
     code: magic.toString(),
     map: magic.generateMap({ source: id, hires: true }),
+    count,
   };
 }
 
@@ -149,9 +153,11 @@ function isStrippableFactoryCall(
 
 /**
  * Blank the message argument and remove prose properties from the options
- * object of a call. Returns whether any edit was made.
+ * object of a call. The call is assumed to follow the `(message, options)`
+ * shape shared by `new VercelError()` and the `createErrors` factory methods.
+ * Returns whether any edit was made.
  */
-function stripCall(magic: MagicString, node: AnyNode): boolean {
+function stripCall(magic: MagicString, code: string, node: AnyNode): boolean {
   const args = node.arguments ?? [];
   if (args.length === 0) return false;
 
@@ -165,7 +171,7 @@ function stripCall(magic: MagicString, node: AnyNode): boolean {
 
   const options = args[1];
   if (options?.type === 'ObjectExpression') {
-    changed = stripProseProps(magic, options) || changed;
+    changed = stripProseProps(magic, code, options) || changed;
   }
 
   return changed;
@@ -174,17 +180,20 @@ function stripCall(magic: MagicString, node: AnyNode): boolean {
 /**
  * Remove prose properties from an options object literal. Skips objects that
  * contain spreads, since their final shape is not statically known. Each
- * removed property also consumes one adjacent comma so the object stays valid.
+ * removed property also consumes its trailing comma (or the preceding comma
+ * when it is the last property) so the object stays valid.
  */
-function stripProseProps(magic: MagicString, object: AnyNode): boolean {
+function stripProseProps(
+  magic: MagicString,
+  code: string,
+  object: AnyNode,
+): boolean {
   const props = (object.properties ?? []) as AnyNode[];
   if (props.some((p) => p.type === 'SpreadElement')) return false;
 
   let changed = false;
-  for (let i = 0; i < props.length; i++) {
-    const prop = props[i];
+  for (const prop of props) {
     if (
-      !prop ||
       prop.type !== 'Property' ||
       prop.key?.type !== 'Identifier' ||
       !PROSE_PROPS.has(prop.key.name)
@@ -192,19 +201,44 @@ function stripProseProps(magic: MagicString, object: AnyNode): boolean {
       continue;
     }
 
-    const next = props[i + 1];
-    const prev = props[i - 1];
-    const start = next
-      ? prop.start // not last: drop the trailing comma by ending at next prop
-      : prev
-        ? prev.end // last with a sibling: drop the preceding comma
-        : prop.start; // sole property: remove just the property
-    const end = next ? next.start : prop.end;
-
-    magic.remove(start, end);
+    const trailingComma = nextCommaIndex(code, prop.end, object.end);
+    if (trailingComma !== -1) {
+      // Remove the property and its trailing comma.
+      magic.remove(prop.start, trailingComma + 1);
+    } else {
+      // Last property: remove it and any preceding comma.
+      magic.remove(prevCommaIndex(code, prop.start, object.start), prop.end);
+    }
     changed = true;
   }
   return changed;
+}
+
+/**
+ * Index of the first comma between `from` and `limit`, skipping whitespace.
+ * Returns -1 when the next non-whitespace character is not a comma (the
+ * property is the last in the object).
+ */
+function nextCommaIndex(code: string, from: number, limit: number): number {
+  for (let i = from; i < limit; i++) {
+    const ch = code[i];
+    if (ch === ',') return i;
+    if (ch !== ' ' && ch !== '\t' && ch !== '\n' && ch !== '\r') return -1;
+  }
+  return -1;
+}
+
+/**
+ * Index of the comma immediately before `from`, scanning back over whitespace.
+ * Falls back to `from` when none is found (the property is the only one).
+ */
+function prevCommaIndex(code: string, from: number, limit: number): number {
+  for (let i = from - 1; i >= limit; i--) {
+    const ch = code[i];
+    if (ch === ',') return i;
+    if (ch !== ' ' && ch !== '\t' && ch !== '\n' && ch !== '\r') break;
+  }
+  return from;
 }
 
 function isStringLiteralLike(node: AnyNode | undefined): boolean {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -10,6 +10,8 @@ export default defineConfig({
     format: 'src/format.ts',
     index: 'src/index.ts',
     server: 'src/server.ts',
+    unplugin: 'src/unplugin/index.ts',
+    'unplugin/loader': 'src/unplugin/loader.ts',
   },
   fixedExtension: false,
   format: ['esm'],


### PR DESCRIPTION
## Summary

Adds a build-time plugin, `@vercel/error/unplugin`, that strips human-readable error prose from production bundles so client bundles shrink. This is the optional, opt-in counterpart to the runtime work in #10. The runtime API is unchanged, and the prod-fallback rendering from #10 makes a stripped error still render as `[scope:code]`.

**Stacked on #10** (`runewolf/docs-base-url-and-prod-fallback`), so this PR targets that branch as its base. Review or merge #10 first.

## What it does

In production builds (`process.env.NODE_ENV === 'production'`), the transform rewrites `new VercelError(...)` and `createErrors` factory calls (`.create`/`.raise`/`.report`) whose bindings come from `@vercel/error`:

- **Removes** the message argument and the `reason`, `hint`, `fix`, `userMessage` options.
- **Keeps** `code`, `scope`, `statusCode`, `link`.
- **Leaves alone** dynamic option objects (spreads, variables) and `metadata`/`attributes`, plus any `VercelError`-named symbol not imported from `@vercel/error`.

```ts
// Source
throw new VercelError('Pool exhausted at 10.0.1.5', {
  code: 'pool_exhausted', scope: 'database', statusCode: 503,
  reason: 'All 20 connections are in use.', fix: 'Increase max_connections.',
});

// Production bundle
throw new VercelError('', { code: 'pool_exhausted', scope: 'database', statusCode: 503 });
```

## Implementation

- **Core transform** (`src/unplugin/transform/index.ts`): `oxc-parser` to find call sites via local import-binding and factory-binding analysis, `magic-string` to rewrite with sourcemaps. Conservative: bails on spreads, non-literal messages, untracked bindings.
- **unplugin factory** (`src/unplugin/index.ts`): `vercelErrorStrip` exposing `.vite()`, `.rollup()`, `.rolldown()`, `.webpack()`, `.esbuild()`, `.rspack()`. Gated to production; `enforce: 'pre'`.
- **Turbopack** (`src/unplugin/loader.ts`): webpack-loader form, since Turbopack runs webpack loaders but not unplugin. Wired via `turbopack.rules` + `condition: 'production'`.
- **Packaging**: new `./unplugin` and `./unplugin/loader` exports. Build deps (`unplugin`, `oxc-parser`, `magic-string`) are **optional `peerDependencies`**, so the core install stays zero-dep. Verified the core entries (`index`/`client`/`server`/`format`) don't reference them and `dependencies` is empty.

## Tests

11 transform specs covering stripping (`new VercelError`, aliased imports, factory calls, mixed prop positions) and safety (non-package symbols, spreads, dynamic messages, untracked objects, output re-parses cleanly). Full suite: 200 tests pass; typecheck, lint, format, and build are green.

## Notes

- Single-package for now; sub-packages can come later without changing the public import path.
- Defaults-only options (`enabled`, `include`) for v1.