### PR TITLE
fix: avoid consumer hook installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vercel/error
 
+## 0.0.3
+
+### Patch Changes
+
+- Stop running Lefthook when consumers install the package.
+
 ## 0.0.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/error",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A lightweight toolkit for structured, actionable errors for humans and agents",
   "author": "Vercel",
   "repository": {
@@ -21,7 +21,7 @@
     "format": "oxfmt --check",
     "format:fix": "oxfmt .",
     "prepublishOnly": "pnpm build",
-    "postinstall": "lefthook install || true",
+    "prepare": "lefthook install || true",
     "validate": "pnpm run --parallel '/^(typecheck|lint|format|test)$/'"
   },
   "devDependencies": {


### PR DESCRIPTION
Installing `@vercel/error` currently runs `lefthook install || true` through `postinstall` in every consuming repository. That is unrelated to using the runtime package, can modify consumer Git hooks, and can fail on platforms where the POSIX `true` fallback is unavailable.

Move Lefthook setup to `prepare`, which keeps hook installation for contributors and package preparation without running it for registry consumers. This also publishes the fix as `0.0.3` with a matching changelog entry.

A packed `0.0.3` manifest contains `prepare` and no `postinstall`.