### PR TITLE
ci: enforce public export size budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,7 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
-      - name: Build
-        run: pnpm build
-
-      - name: Check bundle size
-        run: pnpm size
-
-      - name: Verify README bundle-size table
+      - name: Verify bundle size and README table
         run: |
           pnpm size:readme
           git diff --exit-code README.md \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,15 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Check bundle size
+        run: pnpm size
+
+      - name: Verify README bundle-size table
+        run: |
+          pnpm size:readme
+          git diff --exit-code README.md \
+            || (echo "README bundle-size table is stale. Run 'pnpm size:readme' and commit the result." && exit 1)
+
       - name: Verify packed package
         run: pnpm verify:packed
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,13 +54,7 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
-      - name: Build
-        run: pnpm build
-
-      - name: Check bundle size
-        run: pnpm size
-
-      - name: Verify README bundle-size table
+      - name: Verify bundle size and README table
         run: |
           pnpm size:readme
           git diff --exit-code README.md \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,15 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Check bundle size
+        run: pnpm size
+
+      - name: Verify README bundle-size table
+        run: |
+          pnpm size:readme
+          git diff --exit-code README.md \
+            || (echo "README bundle-size table is stale. Run 'pnpm size:readme' and commit the result." && exit 1)
+
       - name: Verify packed package
         run: pnpm verify:packed
 

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,0 +1,75 @@
+name: Size
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+concurrency:
+  group: size-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  size:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      count: ${{ steps.measure.outputs.count }}
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check bundle size
+        id: measure
+        shell: bash
+        run: |
+          set -o pipefail
+          pnpm exec size-limit --json | tee "$RUNNER_TEMP/size-limit.json"
+          COUNT=$(node -p "JSON.parse(require('node:fs').readFileSync(process.env.RUNNER_TEMP + '/size-limit.json', 'utf8')).length")
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+  comment:
+    needs: size
+    if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment bundle-size result
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+          SIZE_RESULT: ${{ needs.size.result }}
+          COUNT: ${{ needs.size.outputs.count }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -o pipefail
+          MARKER='<!-- error-size-report -->'
+          if [[ "$SIZE_RESULT" == "success" ]]; then
+            MESSAGE="Bundle-size budgets passed for ${COUNT} measured exports."
+          else
+            MESSAGE="Bundle-size check failed. [View the workflow run]($RUN_URL) for details."
+          fi
+          BODY=$(printf '%s\n%s' "$MARKER" "$MESSAGE")
+
+          COMMENT_ID=$(gh api --paginate --slurp "repos/$REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" \
+            | jq -r 'map(.[]) | map(select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- error-size-report -->")))) | last | .id // empty')
+
+          if [[ -n "$COMMENT_ID" ]]; then
+            gh api --method PATCH "repos/$REPOSITORY/issues/comments/$COMMENT_ID" -f body="$BODY"
+          else
+            gh api --method POST "repos/$REPOSITORY/issues/$PR_NUMBER/comments" -f body="$BODY"
+          fi

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,4 +1,4 @@
-name: Size
+name: Bundle Size
 
 on:
   pull_request:
@@ -34,6 +34,8 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
+          pnpm build
+          node scripts/verify-size-coverage.mjs
           pnpm exec size-limit --json | tee "$RUNNER_TEMP/size-limit.json"
           COUNT=$(node -p "JSON.parse(require('node:fs').readFileSync(process.env.RUNNER_TEMP + '/size-limit.json', 'utf8')).length")
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
@@ -59,7 +61,7 @@ jobs:
           set -o pipefail
           MARKER='<!-- error-size-report -->'
           if [[ "$SIZE_RESULT" == "success" ]]; then
-            MESSAGE="Bundle-size budgets passed for ${COUNT} measured exports."
+            MESSAGE="All ${COUNT} public runtime exports are within their bundle-size budgets."
           else
             MESSAGE="Bundle-size check failed. [View the workflow run]($RUN_URL) for details."
           fi

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,103 +1,103 @@
 [
   {
     "name": "VercelError",
-    "path": "src/index.ts",
+    "path": "dist/index.js",
     "import": "{ VercelError }",
     "limit": "1.8 kB"
   },
   {
     "name": "createErrors",
-    "path": "src/index.ts",
+    "path": "dist/index.js",
     "import": "{ createErrors }",
     "limit": "2.05 kB"
   },
   {
     "name": "isVercelError",
-    "path": "src/index.ts",
+    "path": "dist/index.js",
     "import": "{ isVercelError }",
     "limit": "1.95 kB"
   },
   {
     "name": "isError",
-    "path": "src/index.ts",
+    "path": "dist/index.js",
     "import": "{ isError }",
-    "limit": "110 B"
+    "limit": "125 B"
   },
   {
     "name": "isErrorLike",
-    "path": "src/index.ts",
+    "path": "dist/index.js",
     "import": "{ isErrorLike }",
-    "limit": "85 B"
+    "limit": "100 B"
   },
   {
     "name": "hasCode",
-    "path": "src/index.ts",
+    "path": "dist/index.js",
     "import": "{ hasCode }",
-    "limit": "120 B"
+    "limit": "130 B"
   },
   {
     "name": "getMessage",
-    "path": "src/index.ts",
+    "path": "dist/index.js",
     "import": "{ getMessage }",
     "limit": "190 B"
   },
   {
     "name": "getRootCause",
-    "path": "src/index.ts",
+    "path": "dist/index.js",
     "import": "{ getRootCause }",
     "limit": "160 B"
   },
   {
     "name": "fromErrorResponse",
-    "path": "src/client.ts",
+    "path": "dist/client.js",
     "import": "{ fromErrorResponse }",
     "limit": "1.85 kB"
   },
   {
     "name": "parseErrorResponse",
-    "path": "src/client.ts",
+    "path": "dist/client.js",
     "import": "{ parseErrorResponse }",
     "limit": "260 B"
   },
   {
     "name": "errorResponse",
-    "path": "src/server.ts",
+    "path": "dist/server.js",
     "import": "{ errorResponse }",
     "limit": "2.6 kB"
   },
   {
     "name": "wantsAnsi",
-    "path": "src/server.ts",
+    "path": "dist/server.js",
     "import": "{ wantsAnsi }",
     "limit": "175 B"
   },
   {
     "name": "formatError",
-    "path": "src/format.ts",
+    "path": "dist/format.js",
     "import": "{ formatError }",
     "limit": "1.3 kB"
   },
   {
     "name": "frame",
-    "path": "src/format.ts",
+    "path": "dist/format.js",
     "import": "{ frame }",
     "limit": "1.15 kB"
   },
   {
     "name": "hint",
-    "path": "src/format.ts",
+    "path": "dist/format.js",
     "import": "{ hint }",
     "limit": "65 B"
   },
   {
     "name": "fix",
-    "path": "src/format.ts",
+    "path": "dist/format.js",
     "import": "{ fix }",
     "limit": "65 B"
   },
   {
     "name": "link",
-    "path": "src/format.ts",
+    "path": "dist/format.js",
     "import": "{ link }",
     "limit": "65 B"
   }

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,0 +1,104 @@
+[
+  {
+    "name": "VercelError",
+    "path": "src/index.ts",
+    "import": "{ VercelError }",
+    "limit": "1.8 kB"
+  },
+  {
+    "name": "createErrors",
+    "path": "src/index.ts",
+    "import": "{ createErrors }",
+    "limit": "2.05 kB"
+  },
+  {
+    "name": "isVercelError",
+    "path": "src/index.ts",
+    "import": "{ isVercelError }",
+    "limit": "1.95 kB"
+  },
+  {
+    "name": "isError",
+    "path": "src/index.ts",
+    "import": "{ isError }",
+    "limit": "110 B"
+  },
+  {
+    "name": "isErrorLike",
+    "path": "src/index.ts",
+    "import": "{ isErrorLike }",
+    "limit": "85 B"
+  },
+  {
+    "name": "hasCode",
+    "path": "src/index.ts",
+    "import": "{ hasCode }",
+    "limit": "120 B"
+  },
+  {
+    "name": "getMessage",
+    "path": "src/index.ts",
+    "import": "{ getMessage }",
+    "limit": "190 B"
+  },
+  {
+    "name": "getRootCause",
+    "path": "src/index.ts",
+    "import": "{ getRootCause }",
+    "limit": "160 B"
+  },
+  {
+    "name": "fromErrorResponse",
+    "path": "src/client.ts",
+    "import": "{ fromErrorResponse }",
+    "limit": "1.85 kB"
+  },
+  {
+    "name": "parseErrorResponse",
+    "path": "src/client.ts",
+    "import": "{ parseErrorResponse }",
+    "limit": "260 B"
+  },
+  {
+    "name": "errorResponse",
+    "path": "src/server.ts",
+    "import": "{ errorResponse }",
+    "limit": "2.6 kB"
+  },
+  {
+    "name": "wantsAnsi",
+    "path": "src/server.ts",
+    "import": "{ wantsAnsi }",
+    "limit": "175 B"
+  },
+  {
+    "name": "formatError",
+    "path": "src/format.ts",
+    "import": "{ formatError }",
+    "limit": "1.3 kB"
+  },
+  {
+    "name": "frame",
+    "path": "src/format.ts",
+    "import": "{ frame }",
+    "limit": "1.15 kB"
+  },
+  {
+    "name": "hint",
+    "path": "src/format.ts",
+    "import": "{ hint }",
+    "limit": "65 B"
+  },
+  {
+    "name": "fix",
+    "path": "src/format.ts",
+    "import": "{ fix }",
+    "limit": "65 B"
+  },
+  {
+    "name": "link",
+    "path": "src/format.ts",
+    "import": "{ link }",
+    "limit": "65 B"
+  }
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vercel/error
 
+## 0.1.1
+
+### Patch Changes
+
+- Add per-export bundle-size budgets, generated README measurements, and CI enforcement.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -57,35 +57,35 @@ Everything outside `public` is developer-facing and stays out of HTTP responses.
 
 ## Bundle size
 
-Every runtime export is individually measured with [Size Limit](https://github.com/ai/size-limit) and budgeted in CI. Sizes reflect minified and Brotli-compressed bytes.
+[Size Limit](https://github.com/ai/size-limit) measures the minified, Brotli-compressed bundle produced when only one runtime export is imported from the built package, including the code it depends on. CI enforces a separate budget for every runtime export.
 
 > Regenerate with `pnpm size:readme`.
 
 <!-- SIZE-TABLE:START -->
 
-| Export               | Size (min+brotli) |
-| -------------------- | ----------------: |
-| **Root**             |                   |
-| `VercelError`        |           1.69 kB |
-| `createErrors`       |           1.92 kB |
-| `isVercelError`      |           1.84 kB |
-| `isError`            |              91 B |
-| `isErrorLike`        |              69 B |
-| `hasCode`            |              99 B |
-| `getMessage`         |             167 B |
-| `getRootCause`       |             135 B |
-| **Client**           |                   |
-| `fromErrorResponse`  |           1.75 kB |
-| `parseErrorResponse` |             233 B |
-| **Server**           |                   |
-| `errorResponse`      |           2.44 kB |
-| `wantsAnsi`          |             152 B |
-| **Format**           |                   |
-| `formatError`        |            1.2 kB |
-| `frame`              |           1.06 kB |
-| `hint`               |              52 B |
-| `fix`                |              51 B |
-| `link`               |              51 B |
+| Entry point or export    | Size (min+brotli) |
+| ------------------------ | ----------------: |
+| **@vercel/error**        |                   |
+| `VercelError`            |           1.69 kB |
+| `createErrors`           |           1.91 kB |
+| `isVercelError`          |           1.83 kB |
+| `isError`                |             108 B |
+| `isErrorLike`            |              85 B |
+| `hasCode`                |             111 B |
+| `getMessage`             |             170 B |
+| `getRootCause`           |             145 B |
+| **@vercel/error/client** |                   |
+| `fromErrorResponse`      |           1.76 kB |
+| `parseErrorResponse`     |             245 B |
+| **@vercel/error/server** |                   |
+| `errorResponse`          |           2.44 kB |
+| `wantsAnsi`              |             153 B |
+| **@vercel/error/format** |                   |
+| `formatError`            |            1.2 kB |
+| `frame`                  |           1.06 kB |
+| `hint`                   |              52 B |
+| `fix`                    |              51 B |
+| `link`                   |              51 B |
 
 <!-- SIZE-TABLE:END -->
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,40 @@ Everything outside `public` is developer-facing and stays out of HTTP responses.
 | `@vercel/error/server` | `errorResponse`, `wantsAnsi`, `ErrorResponseInput`, `ErrorResponse`, `ErrorResponseOptions`, `HeadersLike` |
 | `@vercel/error/format` | `formatError`, `frame`, `hint`, `fix`, `link`, format and section types                                    |
 
+## Bundle size
+
+Every runtime export is individually measured with [Size Limit](https://github.com/ai/size-limit) and budgeted in CI. Sizes reflect minified and Brotli-compressed bytes.
+
+> Regenerate with `pnpm size:readme`.
+
+<!-- SIZE-TABLE:START -->
+
+| Export               | Size (min+brotli) |
+| -------------------- | ----------------: |
+| **Root**             |                   |
+| `VercelError`        |           1.69 kB |
+| `createErrors`       |           1.92 kB |
+| `isVercelError`      |           1.84 kB |
+| `isError`            |              91 B |
+| `isErrorLike`        |              69 B |
+| `hasCode`            |              99 B |
+| `getMessage`         |             167 B |
+| `getRootCause`       |             135 B |
+| **Client**           |                   |
+| `fromErrorResponse`  |           1.75 kB |
+| `parseErrorResponse` |             233 B |
+| **Server**           |                   |
+| `errorResponse`      |           2.44 kB |
+| `wantsAnsi`          |             152 B |
+| **Format**           |                   |
+| `formatError`        |            1.2 kB |
+| `frame`              |           1.06 kB |
+| `hint`               |              52 B |
+| `fix`                |              51 B |
+| `link`               |              51 B |
+
+<!-- SIZE-TABLE:END -->
+
 ## Error contract
 
 ### Identity
@@ -347,26 +381,3 @@ All utilities below are exported from `@vercel/error`:
 The package runs in browsers, workers, edge runtimes, and Node. `isError` uses the `Error.isError` builtin brand check where the runtime provides it (Node 24, 2025+ evergreen browsers), recognizing errors across realms without traversing caller-controlled prototype chains or consulting `Symbol.toStringTag`. Older runtimes fall back to `instanceof` plus `Object.prototype.toString` branding. Disclosure never depends on the guard's precision: `errorResponse()` independently rejects untagged values carrying `name` or `stack`, so the fallback can only reject more inputs, never disclose more.
 
 `isVercelError` uses `instanceof` first, then a package-namespaced `Symbol.for` tag plus data-shape checks. Its cross-realm result narrows to `VercelErrorLike`, a data-only contract. The tag is forgeable, so recognition does not authenticate a producer or authorize disclosure. Use `instanceof VercelError` before invoking local class or subclass methods.
-
-## Migrating to 0.1
-
-Version 0.1 is a clean redesign without compatibility aliases:
-
-| Before 0.1                         | 0.1 replacement                                               |
-| ---------------------------------- | ------------------------------------------------------------- |
-| `userMessage: 'Safe message'`      | `public: { message: 'Safe message' }`                         |
-| Plain response `status: 429`       | Plain response `statusCode: 429`                              |
-| `errorResponse(error, request)`    | `errorResponse(error, { request })`                           |
-| Factory option `report`            | Factory option `onReport`                                     |
-| `ErrorConstructor` type            | `VercelErrorConstructor` type                                 |
-| Helper output such as `'fix: ...'` | Structured `FrameSection` from `fix(...)`                     |
-| Cross-realm class-method access    | Data access after `isVercelError`; methods after `instanceof` |
-| `ErrorResponseParams` type         | `ErrorResponseInput` type                                     |
-| Structured `ErrorResponse` type    | `ErrorResponseData` type                                      |
-| `ErrorResponseResult` type         | Concrete `ErrorResponse` type                                 |
-
-`ErrorResponseData.error.scope` is now included when set. Check that your `scope` values are safe to show clients before upgrading. `parseErrorResponse()` now rejects the whole response when any present known field has the wrong type; it still ignores unknown fields. `errorResponse()` rejects non-integer `statusCode` values and integers outside 400 through 599. `onReport` must be synchronous; an async legacy `report` callback no longer type-checks. The 0.0 recognition tag has no meaning in 0.1: a 0.0 error instance is rejected like any untagged `Error`, and 0.0-tagged plain data is treated as ordinary flat public input, so every field it carries is disclosed. Recreate upstream errors with explicit `public` details.
-
-The 0.1 public types mark authored `VercelError` fields and every `ErrorResponseInput`, `ErrorResponseData`, and `ErrorResponse` field readonly. Pass authored values at construction or create a new error instead of mutating them. `requestId`, `metadata`, and `attributes` remain mutable for boundary enrichment.
-
-Developer `reason`, `hint`, `fix`, and `link` no longer cross HTTP automatically. Move only approved client-facing values under `public`. Both JSON and negotiated text use those same `public` details.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint:fix": "oxlint --fix .",
     "format": "oxfmt --check",
     "format:fix": "oxfmt .",
-    "size": "size-limit",
+    "size": "pnpm build && node scripts/verify-size-coverage.mjs && size-limit",
     "size:readme": "node scripts/update-size-table.mjs",
     "prepublishOnly": "pnpm build",
     "prepare": "lefthook install || true",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/error",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A lightweight toolkit for structured, actionable errors for humans and agents",
   "license": "MIT",
   "author": "Vercel",
@@ -23,16 +23,20 @@
     "lint:fix": "oxlint --fix .",
     "format": "oxfmt --check",
     "format:fix": "oxfmt .",
+    "size": "size-limit",
+    "size:readme": "node scripts/update-size-table.mjs",
     "prepublishOnly": "pnpm build",
     "prepare": "lefthook install || true",
-    "validate": "pnpm run --parallel '/^(typecheck|lint|format|test)$/'"
+    "validate": "pnpm run --parallel '/^(typecheck|lint|format|test|size)$/'"
   },
   "devDependencies": {
+    "@size-limit/preset-small-lib": "12.1.0",
     "@types/node": "25.6.0",
     "lefthook": "2.1.5",
     "oxfmt": "0.44.0",
     "oxlint": "1.59.0",
     "skills": "1.5.23",
+    "size-limit": "12.1.0",
     "tsdown": "0.21.7",
     "typescript": "6.0.2",
     "vitest": "4.1.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@size-limit/preset-small-lib':
+        specifier: 12.1.0
+        version: 12.1.0(size-limit@12.1.0)
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
@@ -20,6 +23,9 @@ importers:
       oxlint:
         specifier: 1.59.0
         version: 1.59.0
+      size-limit:
+        specifier: 12.1.0
+        version: 12.1.0
       skills:
         specifier: 1.5.23
         version: 1.5.23
@@ -31,7 +37,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(yaml@2.9.0))
+        version: 4.1.4(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.2)(yaml@2.9.0))
 
 packages:
 
@@ -64,6 +70,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -537,6 +699,23 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.15':
     resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
+  '@size-limit/esbuild@12.1.0':
+    resolution: {integrity: sha512-Um6MVrX+05kIxI4+zk0ZByG9dA/Th1f+sfGc571D95BnCPc90/pl2+2OdsQuOyoWEbeAMqfcTKo0v07i+E65Vw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      size-limit: 12.1.0
+
+  '@size-limit/file@12.1.0':
+    resolution: {integrity: sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      size-limit: 12.1.0
+
+  '@size-limit/preset-small-lib@12.1.0':
+    resolution: {integrity: sha512-TVVQ/iuHbaGtHJrjur5s4XKYEyGk0nIwUAqhuzhKPbTyV9nYOH/laDelQ4vg3cGmm8sayRx998wxEdnwM/Yewg==}
+    peerDependencies:
+      size-limit: 12.1.0
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -602,6 +781,10 @@ packages:
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
+  bytes-iec@3.1.1:
+    resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
+    engines: {node: '>= 0.8'}
+
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
@@ -639,6 +822,11 @@ packages:
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -804,6 +992,10 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -819,6 +1011,14 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
+  nanospinner@1.2.2:
+    resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -894,6 +1094,16 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  size-limit@12.1.0:
+    resolution: {integrity: sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      jiti: ^2.0.0
+    peerDependenciesMeta:
+      jiti:
+        optional: true
 
   skills@1.5.23:
     resolution: {integrity: sha512-+hMNBSi35yfX0sKD+ZcRm9y5or7u313OdkcvrRvJAsAzGCaA8wRTu2OmVdN0KRbk9ybqKby5dijkn6OVvNTUmw==}
@@ -1125,6 +1335,84 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@isaacs/fs-minipass@4.0.1':
@@ -1377,6 +1665,22 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.15': {}
 
+  '@size-limit/esbuild@12.1.0(size-limit@12.1.0)':
+    dependencies:
+      esbuild: 0.28.2
+      nanoid: 5.1.16
+      size-limit: 12.1.0
+
+  '@size-limit/file@12.1.0(size-limit@12.1.0)':
+    dependencies:
+      size-limit: 12.1.0
+
+  '@size-limit/preset-small-lib@12.1.0(size-limit@12.1.0)':
+    dependencies:
+      '@size-limit/esbuild': 12.1.0(size-limit@12.1.0)
+      '@size-limit/file': 12.1.0(size-limit@12.1.0)
+      size-limit: 12.1.0
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.1':
@@ -1408,13 +1712,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@25.6.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.2)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(@types/node@25.6.0)(yaml@2.9.0)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.2)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -1452,6 +1756,8 @@ snapshots:
 
   birpc@4.0.0: {}
 
+  bytes-iec@3.1.1: {}
+
   cac@7.0.0: {}
 
   chai@6.2.2: {}
@@ -1469,6 +1775,35 @@ snapshots:
   empathic@2.0.0: {}
 
   es-module-lexer@2.0.0: {}
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
 
   estree-walker@3.0.3:
     dependencies:
@@ -1585,6 +1920,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lilconfig@3.1.3: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1596,6 +1933,12 @@ snapshots:
       minipass: 7.1.3
 
   nanoid@3.3.11: {}
+
+  nanoid@5.1.16: {}
+
+  nanospinner@1.2.2:
+    dependencies:
+      picocolors: 1.1.1
 
   obug@2.1.1: {}
 
@@ -1728,6 +2071,14 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  size-limit@12.1.0:
+    dependencies:
+      bytes-iec: 3.1.1
+      lilconfig: 3.1.3
+      nanospinner: 1.2.2
+      picocolors: 1.1.1
+      tinyglobby: 0.2.16
+
   skills@1.5.23:
     dependencies:
       tar: 7.5.22
@@ -1807,7 +2158,7 @@ snapshots:
     dependencies:
       rolldown: 1.0.0-rc.15
 
-  vite@8.0.8(@types/node@25.6.0)(yaml@2.9.0):
+  vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.2)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -1816,13 +2167,14 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.6.0
+      esbuild: 0.28.2
       fsevents: 2.3.3
       yaml: 2.9.0
 
-  vitest@4.1.4(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(yaml@2.9.0)):
+  vitest@4.1.4(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.2)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.2)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -1839,7 +2191,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@25.6.0)(yaml@2.9.0)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.2)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0

--- a/scripts/update-size-table.mjs
+++ b/scripts/update-size-table.mjs
@@ -1,0 +1,79 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+const readmePath = resolve(root, 'README.md');
+const configPath = resolve(root, '.size-limit.json');
+
+const startMarker = '<!-- SIZE-TABLE:START -->';
+const endMarker = '<!-- SIZE-TABLE:END -->';
+
+const groupByPath = {
+  'src/index.ts': 'Root',
+  'src/client.ts': 'Client',
+  'src/server.ts': 'Server',
+  'src/format.ts': 'Format',
+};
+
+function formatBytes(bytes) {
+  if (bytes < 1000) return `${bytes} B`;
+
+  const kilobytes = bytes / 1000;
+  const formatted =
+    kilobytes % 1 === 0
+      ? kilobytes.toFixed(0)
+      : kilobytes.toFixed(2).replace(/0$/, '');
+  return `${formatted} kB`;
+}
+
+function buildTable(entries, config) {
+  const configByName = new Map(config.map((entry) => [entry.name, entry]));
+  const groups = new Map();
+
+  for (const entry of entries) {
+    const configured = configByName.get(entry.name);
+    const group = groupByPath[configured?.path] ?? 'Other';
+    if (!groups.has(group)) groups.set(group, []);
+    groups.get(group).push(entry);
+  }
+
+  const rows = ['| Export | Size (min+brotli) |', '| --- | ---: |'];
+  for (const label of ['Root', 'Client', 'Server', 'Format', 'Other']) {
+    const items = groups.get(label);
+    if (!items) continue;
+
+    rows.push(`| **${label}** | |`);
+    for (const entry of items) {
+      rows.push(`| \`${entry.name}\` | ${formatBytes(entry.size)} |`);
+    }
+  }
+
+  return rows.join('\n');
+}
+
+const config = JSON.parse(readFileSync(configPath, 'utf8'));
+const output = execFileSync('pnpm', ['exec', 'size-limit', '--json'], {
+  cwd: root,
+  encoding: 'utf8',
+});
+const table = buildTable(JSON.parse(output), config);
+
+const readme = readFileSync(readmePath, 'utf8');
+const startIndex = readme.indexOf(startMarker);
+const endIndex = readme.indexOf(endMarker);
+
+if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+  throw new Error('Missing or invalid SIZE-TABLE markers in README.md');
+}
+
+const updated = `${readme.slice(0, startIndex + startMarker.length)}
+${table}
+${readme.slice(endIndex)}`;
+
+writeFileSync(readmePath, updated);
+execFileSync('pnpm', ['exec', 'oxfmt', readmePath], {
+  cwd: root,
+  stdio: 'inherit',
+});
+console.log('README.md size table updated.');

--- a/scripts/update-size-table.mjs
+++ b/scripts/update-size-table.mjs
@@ -5,16 +5,28 @@ import { resolve } from 'node:path';
 const root = resolve(import.meta.dirname, '..');
 const readmePath = resolve(root, 'README.md');
 const configPath = resolve(root, '.size-limit.json');
+const pnpmCli = process.env.npm_execpath;
+
+if (!pnpmCli) {
+  throw new Error('Run this script through pnpm size:readme');
+}
 
 const startMarker = '<!-- SIZE-TABLE:START -->';
 const endMarker = '<!-- SIZE-TABLE:END -->';
 
 const groupByPath = {
-  'src/index.ts': 'Root',
-  'src/client.ts': 'Client',
-  'src/server.ts': 'Server',
-  'src/format.ts': 'Format',
+  'dist/index.js': '@vercel/error',
+  'dist/client.js': '@vercel/error/client',
+  'dist/server.js': '@vercel/error/server',
+  'dist/format.js': '@vercel/error/format',
 };
+
+function runPnpm(args, options = {}) {
+  return execFileSync(process.execPath, [pnpmCli, ...args], {
+    cwd: root,
+    ...options,
+  });
+}
 
 function formatBytes(bytes) {
   if (bytes < 1000) return `${bytes} B`;
@@ -38,8 +50,17 @@ function buildTable(entries, config) {
     groups.get(group).push(entry);
   }
 
-  const rows = ['| Export | Size (min+brotli) |', '| --- | ---: |'];
-  for (const label of ['Root', 'Client', 'Server', 'Format', 'Other']) {
+  const rows = [
+    '| Entry point or export | Size (min+brotli) |',
+    '| --- | ---: |',
+  ];
+  for (const label of [
+    '@vercel/error',
+    '@vercel/error/client',
+    '@vercel/error/server',
+    '@vercel/error/format',
+    'Other',
+  ]) {
     const items = groups.get(label);
     if (!items) continue;
 
@@ -53,8 +74,16 @@ function buildTable(entries, config) {
 }
 
 const config = JSON.parse(readFileSync(configPath, 'utf8'));
-const output = execFileSync('pnpm', ['exec', 'size-limit', '--json'], {
-  cwd: root,
+runPnpm(['build'], { stdio: 'inherit' });
+execFileSync(
+  process.execPath,
+  [resolve(root, 'scripts/verify-size-coverage.mjs')],
+  {
+    cwd: root,
+    stdio: 'inherit',
+  },
+);
+const output = runPnpm(['exec', 'size-limit', '--json'], {
   encoding: 'utf8',
 });
 const table = buildTable(JSON.parse(output), config);
@@ -64,7 +93,9 @@ const startIndex = readme.indexOf(startMarker);
 const endIndex = readme.indexOf(endMarker);
 
 if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
-  throw new Error('Missing or invalid SIZE-TABLE markers in README.md');
+  throw new Error(
+    'README.md must contain SIZE-TABLE:START before SIZE-TABLE:END',
+  );
 }
 
 const updated = `${readme.slice(0, startIndex + startMarker.length)}
@@ -72,8 +103,7 @@ ${table}
 ${readme.slice(endIndex)}`;
 
 writeFileSync(readmePath, updated);
-execFileSync('pnpm', ['exec', 'oxfmt', readmePath], {
-  cwd: root,
+runPnpm(['exec', 'oxfmt', 'README.md'], {
   stdio: 'inherit',
 });
 console.log('README.md size table updated.');

--- a/scripts/verify-size-coverage.mjs
+++ b/scripts/verify-size-coverage.mjs
@@ -1,0 +1,116 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const root = resolve(import.meta.dirname, '..');
+const packageJson = JSON.parse(
+  readFileSync(resolve(root, 'package.json'), 'utf8'),
+);
+const config = JSON.parse(
+  readFileSync(resolve(root, '.size-limit.json'), 'utf8'),
+);
+
+const publicTargets = new Set();
+const problems = [];
+const targets = [];
+let exportCount = 0;
+
+for (const [subpath, target] of Object.entries(packageJson.exports)) {
+  if (typeof target?.default !== 'string') {
+    problems.push(`Package export "${subpath}" has no default runtime target`);
+    continue;
+  }
+
+  const relativeTarget = target.default.replace(/^\.\//, '');
+  const absoluteTarget = resolve(root, relativeTarget);
+  publicTargets.add(relativeTarget);
+
+  if (!existsSync(absoluteTarget)) {
+    problems.push(
+      `Package export "${subpath}" is missing built target "${target.default}"`,
+    );
+    continue;
+  }
+
+  targets.push({ subpath, relativeTarget, absoluteTarget });
+}
+
+const measuredTargets = await Promise.all(
+  targets.map(async (target) => ({
+    subpath: target.subpath,
+    relativeTarget: target.relativeTarget,
+    runtimeExports: Object.keys(
+      await import(pathToFileURL(target.absoluteTarget)),
+    ),
+  })),
+);
+
+const budgetedExportsByPath = new Map();
+const resultNames = new Set();
+for (const entry of config) {
+  const resultName =
+    typeof entry.name === 'string' && entry.name !== ''
+      ? entry.name
+      : '<unnamed>';
+
+  if (!publicTargets.has(entry.path)) {
+    problems.push(`${resultName} measures non-public path ${entry.path}`);
+  }
+  if (typeof entry.limit !== 'string' || entry.limit.trim() === '') {
+    problems.push(`${resultName} has no size limit`);
+  }
+  if (resultNames.has(resultName)) {
+    problems.push(`Size Limit result name ${resultName} is duplicated`);
+  }
+  resultNames.add(resultName);
+
+  const importMatch =
+    typeof entry.import === 'string'
+      ? /^\{\s*([^\s,{}]+)\s*\}$/.exec(entry.import)
+      : null;
+  if (!importMatch) {
+    problems.push(
+      `Size Limit config entry ${resultName} must import exactly one runtime export`,
+    );
+    continue;
+  }
+
+  const importedName = importMatch[1];
+  if (resultName !== importedName) {
+    problems.push(
+      `Size Limit result name ${resultName} must match imported export ${importedName}`,
+    );
+  }
+
+  if (!budgetedExportsByPath.has(entry.path)) {
+    budgetedExportsByPath.set(entry.path, []);
+  }
+  budgetedExportsByPath.get(entry.path).push(importedName);
+}
+
+for (const { subpath, relativeTarget, runtimeExports } of measuredTargets) {
+  const budgetedExports = budgetedExportsByPath.get(relativeTarget) ?? [];
+
+  exportCount += runtimeExports.length;
+  for (const name of runtimeExports) {
+    const matches = budgetedExports.filter((candidate) => candidate === name);
+    if (matches.length !== 1) {
+      problems.push(
+        `Runtime export "${name}" from package export "${subpath}" has ${matches.length} size budget entries`,
+      );
+    }
+  }
+  for (const name of budgetedExports) {
+    if (!runtimeExports.includes(name)) {
+      problems.push(
+        `Size Limit config for package export "${subpath}" defines a budget for unknown runtime export "${name}"`,
+      );
+    }
+  }
+}
+
+if (problems.length > 0) {
+  throw new Error(`Invalid size budget coverage:\n${problems.join('\n')}`);
+}
+
+console.log(`Verified size budgets for ${exportCount} public runtime exports.`);


### PR DESCRIPTION
Changes to a public runtime export could increase client bundle cost without a dedicated budget or a documented baseline. Reviewers also had no generated size table to compare.

This builds the published entry points, verifies that every runtime export has exactly one Size Limit budget, and records each minified, Brotli-compressed bundle in the README. CI and release validation regenerate the table and fail when either a budget or the committed measurements drift. A separate pull-request workflow measures with read-only permissions and grants write access only to the job that updates its result comment.

The README cleanup also removes the obsolete 0.1 migration section.