### PR TITLE
test: verify browser-targeted packed output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vercel/error
 
+## 0.1.3
+
+### Patch Changes
+
+- Verify the packed package as a browser-platform ES2022 IIFE in isolated VM contexts with and without `Error.isError`.
+
 ## 0.1.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/error",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A lightweight toolkit for structured, actionable errors for humans and agents",
   "license": "MIT",
   "author": "Vercel",

--- a/scripts/fixtures/packed-consumer/browser.ts
+++ b/scripts/fixtures/packed-consumer/browser.ts
@@ -1,0 +1,88 @@
+import * as root from '@vercel/error';
+import * as client from '@vercel/error/client';
+import * as format from '@vercel/error/format';
+import * as server from '@vercel/error/server';
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+for (const nodeGlobal of ['process', 'Buffer', 'require']) {
+  assert(
+    !(nodeGlobal in globalThis),
+    'Node VM sandbox unexpectedly exposes global ' + nodeGlobal,
+  );
+}
+
+const runtimeExports = {
+  '.': root,
+  './client': client,
+  './server': server,
+  './format': format,
+};
+(
+  globalThis as typeof globalThis & {
+    __vercelErrorExercisedExports?: Record<string, string[]>;
+  }
+).__vercelErrorExercisedExports = Object.fromEntries(
+  Object.entries(runtimeExports).map(([subpath, exports]) => [
+    subpath,
+    Object.keys(exports).toSorted(),
+  ]),
+);
+
+assert(
+  root.isError(new Error('browser failure')),
+  'isError did not recognize an Error created in the Node VM',
+);
+const acceptsTagForgery = (
+  globalThis as typeof globalThis & {
+    __vercelErrorAcceptsTagForgery: boolean;
+  }
+).__vercelErrorAcceptsTagForgery;
+assert(
+  root.isError({ [Symbol.toStringTag]: 'Error' }) === acceptsTagForgery,
+  'isError did not select the expected recognition branch',
+);
+
+const error = new root.VercelError('DEV_MESSAGE', {
+  code: 'unavailable',
+  public: { message: 'The service is unavailable' },
+  scope: 'browser',
+  statusCode: 503,
+});
+
+const json = server.errorResponse(error);
+assert(
+  json.status === 503,
+  'errorResponse did not map statusCode 503 to response status 503',
+);
+assert(
+  !json.body.includes('DEV_MESSAGE'),
+  'JSON response contains the developer message',
+);
+const parsed = client.parseErrorResponse(JSON.parse(json.body));
+assert(
+  parsed?.error.code === 'unavailable' &&
+    parsed.error.message === 'The service is unavailable',
+  'browser response did not preserve its public identity and message',
+);
+const reconstructed = client.fromErrorResponse(parsed, {
+  statusCode: json.status,
+});
+assert(
+  server.errorResponse(reconstructed).body === json.body,
+  'reconstructed error did not serialize to the same public body',
+);
+assert(
+  format
+    .formatError(reconstructed, { format: 'plain' })
+    .includes('The service is unavailable'),
+  'plain format omitted the reconstructed public message',
+);
+
+(
+  globalThis as typeof globalThis & {
+    __vercelErrorBrowserCheckComplete?: boolean;
+  }
+).__vercelErrorBrowserCheckComplete = true;

--- a/scripts/fixtures/packed-consumer/browser.ts
+++ b/scripts/fixtures/packed-consumer/browser.ts
@@ -17,17 +17,17 @@ for (const nodeGlobal of ['process', 'Buffer', 'require']) {
 const runtimeExports = {
   '.': root,
   './client': client,
-  './server': server,
   './format': format,
+  './server': server,
 };
 (
   globalThis as typeof globalThis & {
-    __vercelErrorExercisedExports?: Record<string, string[]>;
+    __vercelErrorRuntimeExportKeys?: Record<string, string[]>;
   }
-).__vercelErrorExercisedExports = Object.fromEntries(
+).__vercelErrorRuntimeExportKeys = Object.fromEntries(
   Object.entries(runtimeExports).map(([subpath, exports]) => [
     subpath,
-    Object.keys(exports).toSorted(),
+    Object.keys(exports),
   ]),
 );
 
@@ -64,14 +64,17 @@ assert(
 const parsed = client.parseErrorResponse(JSON.parse(json.body));
 assert(
   parsed?.error.code === 'unavailable' &&
+    parsed.error.scope === 'browser' &&
     parsed.error.message === 'The service is unavailable',
-  'browser response did not preserve its public identity and message',
+  'browser-platform bundle response did not preserve its public identity and message',
 );
 const reconstructed = client.fromErrorResponse(parsed, {
   statusCode: json.status,
 });
+const reconstructedResponse = server.errorResponse(reconstructed);
 assert(
-  server.errorResponse(reconstructed).body === json.body,
+  reconstructedResponse.status === json.status &&
+    reconstructedResponse.body === json.body,
   'reconstructed error did not serialize to the same public body',
 );
 assert(

--- a/scripts/fixtures/packed-consumer/consumer.ts
+++ b/scripts/fixtures/packed-consumer/consumer.ts
@@ -1,0 +1,201 @@
+import {
+  VercelError,
+  createErrors,
+  hasCode,
+  isErrorLike,
+  isVercelError,
+  type ErrorResponseData,
+  type VercelErrorOptions,
+} from '@vercel/error';
+import {
+  fromErrorResponse,
+  parseErrorResponse,
+  type ErrorResponseData as ClientErrorResponseData,
+} from '@vercel/error/client';
+import { fix, formatError, frame, hint, link } from '@vercel/error/format';
+import {
+  errorResponse,
+  wantsAnsi,
+  type ErrorResponse,
+  type ErrorResponseInput,
+} from '@vercel/error/server';
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+type VisitorCode = 'bad_request' | 'unavailable';
+let reportedCode: VisitorCode | undefined;
+const visitorErrors = createErrors<VisitorCode>({
+  scope: 'visitor-signals',
+  onReport: (error) => {
+    reportedCode = error.code;
+  },
+});
+const reported = visitorErrors.report('Internal visitor failure', {
+  code: 'unavailable',
+  public: { message: 'Visitor signals are unavailable' },
+  statusCode: 503,
+});
+assert(reportedCode === 'unavailable', 'typed scoped report callback failed');
+
+const publicInput: ErrorResponseInput = {
+  message: 'Public input failed',
+  statusCode: 400,
+};
+const publicResponse: ErrorResponse = errorResponse(publicInput);
+assert(
+  publicResponse.status === 400,
+  'ErrorResponseInput status was not preserved in ErrorResponse',
+);
+
+type CliErrorOptions = VercelErrorOptions<'cli_failure'>;
+class CliError extends VercelError<'cli_failure'> {
+  readonly retryable = true;
+  constructor(message: string, options: CliErrorOptions = {}) {
+    super(message, options);
+    this.name = 'CliError';
+  }
+}
+const cliErrors = createErrors({ ErrorClass: CliError, scope: 'cli' });
+const cliError = cliErrors.create('CLI failed', { code: 'cli_failure' });
+assert(cliError.retryable, 'custom CliError instance was not retryable');
+assert(hasCode(cliError, 'cli_failure'), 'hasCode failed');
+assert(isErrorLike(cliError), 'isErrorLike failed');
+const unknownCliError: unknown = cliError;
+if (hasCode(unknownCliError, 'cli_failure')) {
+  const exactCode: 'cli_failure' = unknownCliError.code;
+  assert(exactCode === 'cli_failure', 'hasCode narrowing failed');
+}
+if (isErrorLike(unknownCliError)) {
+  const message: string = unknownCliError.message;
+  assert(message === 'CLI failed', 'isErrorLike narrowing failed');
+}
+if (isVercelError(unknownCliError)) {
+  const metadata = unknownCliError.metadata;
+  assert(metadata === undefined, 'isVercelError narrowing failed');
+}
+
+function verifyTypeContracts(error: CliError, data: ErrorResponseData): void {
+  error.requestId = 'req_123';
+  error.metadata = { operation: 'deploy' };
+  error.attributes = { retryable: true };
+  // @ts-expect-error authored message is readonly
+  error.message = 'changed';
+  // @ts-expect-error authored code is readonly
+  error.code = 'cli_failure';
+  // @ts-expect-error authored status is readonly
+  error.statusCode = 500;
+  // @ts-expect-error authored public details are readonly
+  error.public = { message: 'changed' };
+  // @ts-expect-error ErrorResponseData scope cannot be overridden during reconstruction
+  fromErrorResponse(data, { scope: 'other' });
+  // @ts-expect-error ErrorResponseData code cannot be overridden during reconstruction
+  fromErrorResponse(data, { code: 'other' });
+  // @ts-expect-error ErrorResponseData public details cannot be overridden during reconstruction
+  fromErrorResponse(data, { public: { message: 'other' } });
+}
+assert(
+  typeof verifyTypeContracts === 'function',
+  'type contract fixture was not defined',
+);
+
+// @ts-expect-error custom subtypes require their matching ErrorClass
+createErrors<'cli_failure', CliError>({ scope: 'cli' });
+// @ts-expect-error reporting callbacks must be synchronous
+createErrors({ onReport: async () => undefined });
+// @ts-expect-error serialization callbacks must be synchronous
+errorResponse({ message: 'Failed' }, { onSerialize: async () => undefined });
+
+let serializedStatus: number | undefined;
+let serializedBodyFormat: 'json' | 'ansi' | undefined;
+const json: ErrorResponse = errorResponse(reported, {
+  onSerialize: (_source, context) => {
+    serializedBodyFormat = context.bodyFormat;
+    serializedStatus = context.status;
+  },
+});
+assert(json.status === 503, 'concrete status was not preserved');
+assert(serializedStatus === 503, 'onSerialize did not run');
+assert(serializedBodyFormat === 'json', 'JSON body format was not reported');
+const parsedJson = parseErrorResponse(JSON.parse(json.body));
+assert(parsedJson, 'valid JSON response did not parse');
+const clientResponseData: ClientErrorResponseData = parsedJson;
+assert(
+  clientResponseData.error === parsedJson.error,
+  'client response type alias changed response data',
+);
+assert(parsedJson.error.scope === 'visitor-signals', 'scope did not survive');
+assert(parsedJson.error.code === 'unavailable', 'code did not survive');
+assert(
+  !('requestId' in parsedJson.error),
+  'server-only requestId reached response data',
+);
+
+const reconstructed = fromErrorResponse(parsedJson, {
+  statusCode: json.status,
+});
+assert(
+  reconstructed.public?.message === 'Visitor signals are unavailable',
+  'public details were not reconstructed',
+);
+
+const fallback = errorResponse(new VercelError('Secret developer prose'));
+assert(
+  JSON.parse(fallback.body).error.message === 'An error occurred.',
+  'developer prose leaked through fallback',
+);
+for (const untaggedError of [
+  new Error('Secret untagged developer prose'),
+  new Proxy(new Error('Secret proxied developer prose'), {}),
+]) {
+  let untaggedErrorRejected = false;
+  try {
+    errorResponse(untaggedError);
+  } catch (error) {
+    untaggedErrorRejected = error instanceof TypeError;
+  }
+  assert(untaggedErrorRejected, 'untagged Error-like value was serialized');
+}
+const ansi = errorResponse(reported, {
+  request: new Headers({ 'X-Error-Format': 'ansi' }),
+});
+assert(ansi.body.includes('\x1b['), 'explicit ANSI consulted ambient NO_COLOR');
+assert(
+  ansi.body.includes('Visitor signals are unavailable'),
+  'ANSI output omitted public prose',
+);
+assert(
+  !ansi.body.includes('Internal visitor failure'),
+  'ANSI output disclosed developer prose',
+);
+assert(
+  wantsAnsi(new Headers({ 'X-Error-Format': 'ansi' })),
+  'server subpath negotiation failed',
+);
+
+assert(
+  parseErrorResponse({ error: { hint: false, message: 'Failed' } }) ===
+    undefined,
+  'strict parsing accepted malformed known fields',
+);
+let invalidStatusRejected = false;
+try {
+  errorResponse({ message: 'Failed', statusCode: 399 });
+} catch (error) {
+  invalidStatusRejected = error instanceof RangeError;
+}
+assert(invalidStatusRejected, 'invalid status was not rejected');
+
+assert(
+  formatError(reconstructed, { format: 'plain' }).includes(
+    'Visitor signals are unavailable',
+  ),
+  'format subpath could not render an error',
+);
+assert(
+  frame('Failed', [hint('Try again'), fix('Retry'), link('https://x.dev')], {
+    format: 'tree',
+  }).includes('╰─▸'),
+  'structured frame sections did not render',
+);

--- a/scripts/fixtures/packed-consumer/tsconfig.browser.json
+++ b/scripts/fixtures/packed-consumer/tsconfig.browser.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["browser.ts"]
+}

--- a/scripts/fixtures/packed-consumer/tsdown.browser.config.mjs
+++ b/scripts/fixtures/packed-consumer/tsdown.browser.config.mjs
@@ -1,0 +1,12 @@
+export default {
+  clean: true,
+  deps: {
+    alwaysBundle: [/.*/],
+  },
+  entry: ['browser.ts'],
+  format: ['iife'],
+  logLevel: 'error',
+  outDir: 'browser-bundle',
+  platform: 'browser',
+  target: 'es2022',
+};

--- a/scripts/fixtures/packed-consumer/utility.ts
+++ b/scripts/fixtures/packed-consumer/utility.ts
@@ -1,0 +1,5 @@
+import { hasCode } from '@vercel/error';
+
+export function isUnavailable(error: unknown): boolean {
+  return hasCode(error, 'unavailable');
+}

--- a/scripts/verify-packed-package.mjs
+++ b/scripts/verify-packed-package.mjs
@@ -10,6 +10,7 @@ import {
 import { tmpdir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { runInNewContext } from 'node:vm';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workspace = mkdtempSync(join(tmpdir(), 'vercel-error-packed-'));
@@ -63,6 +64,11 @@ function main() {
     );
     writeFileSync(join(consumerDirectory, 'consumer.ts'), consumerFixture);
     writeFileSync(join(consumerDirectory, 'utility.ts'), utilityFixture);
+    writeFileSync(join(consumerDirectory, 'browser.ts'), browserFixture);
+    writeFileSync(
+      join(consumerDirectory, 'tsdown.browser.config.mjs'),
+      browserBuildConfig,
+    );
 
     const tsc = join(packageRoot, 'node_modules', 'typescript', 'bin', 'tsc');
     execFileSync(process.execPath, [tsc, '--project', 'tsconfig.json'], {
@@ -82,6 +88,7 @@ function main() {
       join(consumerDirectory, 'node_modules/@vercel/error/dist'),
     );
     verifyTreeShaking(consumerDirectory);
+    verifyBrowserBundle(consumerDirectory);
 
     console.log('Packed package verification passed.');
   } finally {
@@ -204,6 +211,81 @@ function verifyTreeShaking(directory) {
     }
     if (bundle.includes(forbidden)) {
       throw new Error(`Tree-shaken utility bundle contains ${forbidden}`);
+    }
+  }
+}
+
+function verifyBrowserBundle(directory) {
+  const tsdown = join(packageRoot, 'node_modules', '.bin', 'tsdown');
+  execFileSync(tsdown, ['--config', 'tsdown.browser.config.mjs'], {
+    cwd: directory,
+    stdio: 'inherit',
+    timeout: 60_000,
+  });
+
+  const bundleDirectory = join(directory, 'browser-bundle');
+  const bundleNames = readdirSync(bundleDirectory).filter((name) =>
+    /\.[cm]?js$/.test(name),
+  );
+  if (bundleNames.length !== 1) {
+    throw new Error(
+      `Expected one top-level browser JavaScript file, found ${bundleNames.length}`,
+    );
+  }
+  const [bundleName] = bundleNames;
+  const bundle = readFileSync(join(bundleDirectory, bundleName), 'utf8');
+
+  if (/\bnode:/.test(bundle)) {
+    throw new Error('Browser bundle text matches /\\bnode:/');
+  }
+  if (/\brequire\s*\(/.test(bundle)) {
+    throw new Error('Browser bundle text matches /\\brequire\\s*\\(/');
+  }
+  if (/\bimport\s*\(/.test(bundle)) {
+    throw new Error('Browser bundle text contains a dynamic import');
+  }
+
+  const nativeBrandCheckAvailable = runInNewContext(
+    "typeof Error.isError === 'function'",
+    Object.create(null),
+  );
+  if (!nativeBrandCheckAvailable) {
+    throw new Error('Packed verification runtime has no native Error.isError');
+  }
+
+  for (const scenario of [
+    { acceptsTagForgery: false, name: 'native Error.isError', setup: '' },
+    {
+      acceptsTagForgery: true,
+      name: 'Error.isError fallback',
+      setup:
+        "Object.defineProperty(Error, 'isError', { configurable: true, value: undefined, writable: true });",
+    },
+  ]) {
+    const sandbox = Object.assign(Object.create(null), {
+      __vercelErrorAcceptsTagForgery: scenario.acceptsTagForgery,
+      document: Object.freeze({}),
+      navigator: Object.freeze({ userAgent: 'packed-browser-check' }),
+    });
+    sandbox.self = sandbox;
+    sandbox.window = sandbox;
+
+    try {
+      runInNewContext(`${scenario.setup}\n${bundle}`, sandbox, {
+        filename: `vercel-error-browser-${scenario.name}.js`,
+        timeout: 5_000,
+      });
+    } catch (error) {
+      throw new Error(
+        `Browser fixture failed in Node VM scenario "${scenario.name}"`,
+        { cause: error },
+      );
+    }
+
+    if (sandbox.__vercelErrorBrowserCheckComplete !== true) {
+      throw new Error(
+        `Browser fixture did not complete in Node VM scenario "${scenario.name}"`,
+      );
     }
   }
 }
@@ -419,6 +501,234 @@ import { hasCode } from '@vercel/error';
 export function isUnavailable(error: unknown): boolean {
   return hasCode(error, 'unavailable');
 }
+`;
+
+const browserBuildConfig = String.raw`
+export default {
+  clean: true,
+  deps: {
+    alwaysBundle: [/.*/],
+  },
+  entry: ['browser.ts'],
+  format: ['iife'],
+  logLevel: 'error',
+  outDir: 'browser-bundle',
+  platform: 'browser',
+  target: 'es2022',
+};
+`;
+
+const browserFixture = String.raw`
+import * as root from '@vercel/error';
+import * as client from '@vercel/error/client';
+import * as server from '@vercel/error/server';
+import * as format from '@vercel/error/format';
+
+const {
+  VercelError,
+  createErrors,
+  getMessage,
+  getRootCause,
+  hasCode,
+  isError,
+  isErrorLike,
+  isVercelError,
+} = root;
+const { fromErrorResponse, parseErrorResponse } = client;
+const { errorResponse, wantsAnsi } = server;
+const { fix, formatError, frame, hint, link } = format;
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+for (const nodeGlobal of ['process', 'Buffer', 'require']) {
+  assert(
+    !(nodeGlobal in globalThis),
+    'Node VM sandbox unexpectedly exposes global ' + nodeGlobal,
+  );
+}
+
+const runtimeExports = {
+  VercelError,
+  createErrors,
+  errorResponse,
+  fix,
+  formatError,
+  frame,
+  fromErrorResponse,
+  getMessage,
+  getRootCause,
+  hasCode,
+  hint,
+  isError,
+  isErrorLike,
+  isVercelError,
+  link,
+  parseErrorResponse,
+  wantsAnsi,
+};
+for (const [name, value] of Object.entries(runtimeExports)) {
+  assert(typeof value === 'function', 'browser bundle omitted export ' + name);
+}
+
+assert(
+  isError(new Error('browser failure')),
+  'isError did not recognize an Error created in the Node VM',
+);
+const acceptsTagForgery = (
+  globalThis as typeof globalThis & {
+    __vercelErrorAcceptsTagForgery: boolean;
+  }
+).__vercelErrorAcceptsTagForgery;
+assert(
+  isError({ [Symbol.toStringTag]: 'Error' }) === acceptsTagForgery,
+  'isError did not select the expected recognition branch',
+);
+
+let plainErrorRejected = false;
+try {
+  errorResponse(new Error('Secret browser failure'));
+} catch (caught) {
+  plainErrorRejected = caught instanceof TypeError;
+}
+assert(
+  plainErrorRejected,
+  'errorResponse did not reject a plain Error with TypeError',
+);
+
+const developerCanaries = [
+  'DEV_MESSAGE',
+  'DEV_NAME',
+  'DEV_REASON',
+  'DEV_HINT',
+  'DEV_FIX',
+  'DEV_LINK',
+  'DEV_REQUEST_ID',
+  'DEV_METADATA',
+  'DEV_ATTRIBUTE',
+  'DEV_CAUSE',
+];
+function assertNoDeveloperCanaries(body: string, formatName: string): void {
+  for (const canary of developerCanaries) {
+    assert(!body.includes(canary), formatName + ' body contains ' + canary);
+  }
+}
+
+const cause = new Error('DEV_CAUSE');
+const errors = createErrors({ scope: 'browser' });
+const error = errors.create('DEV_MESSAGE', {
+  attributes: { diagnostic: 'DEV_ATTRIBUTE' },
+  cause,
+  code: 'unavailable',
+  fix: 'DEV_FIX',
+  hint: 'DEV_HINT',
+  link: 'https://example.com/DEV_LINK',
+  metadata: { diagnostic: 'DEV_METADATA' },
+  public: { message: 'The service is unavailable' },
+  reason: 'DEV_REASON',
+  requestId: 'DEV_REQUEST_ID',
+  statusCode: 503,
+});
+error.name = 'DEV_NAME';
+
+assert(error instanceof VercelError, 'createErrors did not use VercelError');
+assert(hasCode(error, 'unavailable'), 'hasCode did not match the error code');
+assert(isErrorLike(error), 'isErrorLike did not recognize VercelError');
+assert(isVercelError(error), 'isVercelError did not recognize VercelError');
+assert(getMessage(error) === 'DEV_MESSAGE', 'getMessage changed the message');
+assert(getRootCause(error) === cause, 'getRootCause did not return the cause');
+
+const json = errorResponse(error);
+assert(
+  json.status === 503,
+  'errorResponse did not map statusCode 503 to response status 503',
+);
+assert(
+  json.headers['Content-Type'] === 'application/json',
+  'JSON response content type was not application/json',
+);
+assertNoDeveloperCanaries(json.body, 'JSON');
+const jsonData = JSON.parse(json.body);
+assert(
+  Object.keys(jsonData).join(',') === 'error',
+  'JSON response contains unexpected top-level fields',
+);
+assert(
+  Object.keys(jsonData.error).join(',') === 'scope,code,message',
+  'JSON response contains unexpected error fields',
+);
+assert(
+  jsonData.error.scope === 'browser' &&
+    jsonData.error.code === 'unavailable' &&
+    jsonData.error.message === 'The service is unavailable',
+  'JSON response fields do not match the public error',
+);
+
+const parsed = parseErrorResponse(jsonData);
+assert(
+  parsed?.error.message === 'The service is unavailable',
+  'parseErrorResponse did not return the public message',
+);
+const reconstructed = fromErrorResponse(parsed, { statusCode: json.status });
+assert(
+  reconstructed.message === 'The service is unavailable' &&
+    reconstructed.scope === 'browser' &&
+    reconstructed.code === 'unavailable' &&
+    reconstructed.statusCode === 503 &&
+    reconstructed.public?.message === 'The service is unavailable',
+  'fromErrorResponse did not reconstruct the public response fields',
+);
+assert(
+  errorResponse(reconstructed).body === json.body,
+  'reconstructed error did not serialize to the same public body',
+);
+
+const ansiHeaders = {
+  get(name: string): string | null {
+    return name === 'x-error-format' ? 'ansi' : null;
+  },
+};
+assert(
+  wantsAnsi(ansiHeaders),
+  'wantsAnsi did not accept x-error-format: ansi',
+);
+const ansi = errorResponse(error, { request: ansiHeaders });
+assert(
+  ansi.headers['Content-Type'] === 'text/plain; charset=utf-8',
+  'ANSI response content type was not text/plain; charset=utf-8',
+);
+assert(
+  ansi.body.includes('\x1b['),
+  'errorResponse did not emit ANSI control sequences',
+);
+assert(
+  ansi.body.includes('The service is unavailable'),
+  'ANSI response body omitted the public message',
+);
+assertNoDeveloperCanaries(ansi.body, 'ANSI');
+
+assert(
+  formatError(reconstructed, { format: 'plain' }).includes(
+    'The service is unavailable',
+  ),
+  'plain format omitted the reconstructed public message',
+);
+const renderedFrame = frame(
+  'Browser failure',
+  [hint('Try again'), fix('Retry'), link('https://example.com/help')],
+  { format: 'tree' },
+);
+assert(
+  renderedFrame.includes('hint: Try again') &&
+    renderedFrame.includes('fix: Retry') &&
+    renderedFrame.includes('read more: https://example.com/help'),
+  'tree frame omitted a structured section',
+);
+
+(globalThis as typeof globalThis & {
+  __vercelErrorBrowserCheckComplete?: boolean;
+}).__vercelErrorBrowserCheckComplete = true;
 `;
 
 main();

--- a/scripts/verify-packed-package.mjs
+++ b/scripts/verify-packed-package.mjs
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import {
+  copyFileSync,
   existsSync,
   mkdtempSync,
   readFileSync,
@@ -13,6 +14,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { runInNewContext } from 'node:vm';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const fixtureDirectory = join(packageRoot, 'scripts/fixtures/packed-consumer');
 const workspace = mkdtempSync(join(tmpdir(), 'vercel-error-packed-'));
 const packDirectory = join(workspace, 'package');
 const consumerDirectory = join(workspace, 'consumer');
@@ -62,13 +64,17 @@ async function main() {
         include: ['consumer.ts'],
       }),
     );
-    writeFileSync(join(consumerDirectory, 'consumer.ts'), consumerFixture);
-    writeFileSync(join(consumerDirectory, 'utility.ts'), utilityFixture);
-    writeFileSync(join(consumerDirectory, 'browser.ts'), browserFixture);
-    writeFileSync(
-      join(consumerDirectory, 'tsdown.browser.config.mjs'),
-      browserBuildConfig,
-    );
+    for (const fixture of [
+      'browser.ts',
+      'consumer.ts',
+      'tsdown.browser.config.mjs',
+      'utility.ts',
+    ]) {
+      copyFileSync(
+        join(fixtureDirectory, fixture),
+        join(consumerDirectory, fixture),
+      );
+    }
 
     const tsc = join(packageRoot, 'node_modules', 'typescript', 'bin', 'tsc');
     execFileSync(process.execPath, [tsc, '--project', 'tsconfig.json'], {
@@ -318,320 +324,5 @@ async function verifyBrowserBundle(directory) {
     }
   }
 }
-
-const consumerFixture = String.raw`
-import {
-  VercelError,
-  createErrors,
-  hasCode,
-  isErrorLike,
-  isVercelError,
-  type ErrorResponseData,
-  type VercelErrorOptions,
-} from '@vercel/error';
-import {
-  fromErrorResponse,
-  parseErrorResponse,
-  type ErrorResponseData as ClientErrorResponseData,
-} from '@vercel/error/client';
-import {
-  errorResponse,
-  wantsAnsi,
-  type ErrorResponse,
-  type ErrorResponseInput,
-} from '@vercel/error/server';
-import {
-  fix,
-  formatError,
-  frame,
-  hint,
-  link,
-} from '@vercel/error/format';
-
-function assert(condition: unknown, message: string): asserts condition {
-  if (!condition) throw new Error(message);
-}
-
-type VisitorCode = 'bad_request' | 'unavailable';
-let reportedCode: VisitorCode | undefined;
-const visitorErrors = createErrors<VisitorCode>({
-  scope: 'visitor-signals',
-  onReport: (error) => {
-    reportedCode = error.code;
-  },
-});
-const reported = visitorErrors.report('Internal visitor failure', {
-  code: 'unavailable',
-  public: { message: 'Visitor signals are unavailable' },
-  statusCode: 503,
-});
-assert(reportedCode === 'unavailable', 'typed scoped report callback failed');
-
-const publicInput: ErrorResponseInput = {
-  message: 'Public input failed',
-  statusCode: 400,
-};
-const publicResponse: ErrorResponse = errorResponse(publicInput);
-assert(
-  publicResponse.status === 400,
-  'ErrorResponseInput status was not preserved in ErrorResponse',
-);
-
-type CliErrorOptions = VercelErrorOptions<'cli_failure'>;
-class CliError extends VercelError<'cli_failure'> {
-  readonly retryable = true;
-  constructor(message: string, options: CliErrorOptions = {}) {
-    super(message, options);
-    this.name = 'CliError';
-  }
-}
-const cliErrors = createErrors({ ErrorClass: CliError, scope: 'cli' });
-const cliError = cliErrors.create('CLI failed', { code: 'cli_failure' });
-assert(cliError.retryable, 'custom CliError instance was not retryable');
-assert(hasCode(cliError, 'cli_failure'), 'hasCode failed');
-assert(isErrorLike(cliError), 'isErrorLike failed');
-const unknownCliError: unknown = cliError;
-if (hasCode(unknownCliError, 'cli_failure')) {
-  const exactCode: 'cli_failure' = unknownCliError.code;
-  assert(exactCode === 'cli_failure', 'hasCode narrowing failed');
-}
-if (isErrorLike(unknownCliError)) {
-  const message: string = unknownCliError.message;
-  assert(message === 'CLI failed', 'isErrorLike narrowing failed');
-}
-if (isVercelError(unknownCliError)) {
-  const metadata = unknownCliError.metadata;
-  assert(metadata === undefined, 'isVercelError narrowing failed');
-}
-
-function verifyTypeContracts(
-  error: CliError,
-  data: ErrorResponseData,
-): void {
-  error.requestId = 'req_123';
-  error.metadata = { operation: 'deploy' };
-  error.attributes = { retryable: true };
-  // @ts-expect-error authored message is readonly
-  error.message = 'changed';
-  // @ts-expect-error authored code is readonly
-  error.code = 'cli_failure';
-  // @ts-expect-error authored status is readonly
-  error.statusCode = 500;
-  // @ts-expect-error authored public details are readonly
-  error.public = { message: 'changed' };
-  // @ts-expect-error ErrorResponseData scope cannot be overridden during reconstruction
-  fromErrorResponse(data, { scope: 'other' });
-  // @ts-expect-error ErrorResponseData code cannot be overridden during reconstruction
-  fromErrorResponse(data, { code: 'other' });
-  // @ts-expect-error ErrorResponseData public details cannot be overridden during reconstruction
-  fromErrorResponse(data, { public: { message: 'other' } });
-}
-void verifyTypeContracts;
-
-// @ts-expect-error custom subtypes require their matching ErrorClass
-createErrors<'cli_failure', CliError>({ scope: 'cli' });
-// @ts-expect-error reporting callbacks must be synchronous
-createErrors({ onReport: async () => {} });
-// @ts-expect-error serialization callbacks must be synchronous
-errorResponse({ message: 'Failed' }, { onSerialize: async () => {} });
-
-let serializedStatus: number | undefined;
-let serializedBodyFormat: 'json' | 'ansi' | undefined;
-const json: ErrorResponse = errorResponse(reported, {
-  onSerialize: (_source, context) => {
-    serializedBodyFormat = context.bodyFormat;
-    serializedStatus = context.status;
-  },
-});
-assert(json.status === 503, 'concrete status was not preserved');
-assert(serializedStatus === 503, 'onSerialize did not run');
-assert(serializedBodyFormat === 'json', 'JSON body format was not reported');
-const parsedJson = parseErrorResponse(JSON.parse(json.body));
-assert(parsedJson, 'valid JSON response did not parse');
-const clientResponseData: ClientErrorResponseData = parsedJson;
-void clientResponseData;
-assert(parsedJson.error.scope === 'visitor-signals', 'scope did not survive');
-assert(parsedJson.error.code === 'unavailable', 'code did not survive');
-assert(
-  !('requestId' in parsedJson.error),
-  'server-only requestId reached response data',
-);
-
-const reconstructed = fromErrorResponse(parsedJson, { statusCode: json.status });
-assert(
-  reconstructed.public?.message === 'Visitor signals are unavailable',
-  'public details were not reconstructed',
-);
-
-const fallback = errorResponse(new VercelError('Secret developer prose'));
-assert(
-  JSON.parse(fallback.body).error.message === 'An error occurred.',
-  'developer prose leaked through fallback',
-);
-for (const untaggedError of [
-  new Error('Secret untagged developer prose'),
-  new Proxy(new Error('Secret proxied developer prose'), {}),
-]) {
-  let untaggedErrorRejected = false;
-  try {
-    errorResponse(untaggedError);
-  } catch (error) {
-    untaggedErrorRejected = error instanceof TypeError;
-  }
-  assert(untaggedErrorRejected, 'untagged Error-like value was serialized');
-}
-const ansi = errorResponse(reported, {
-  request: new Headers({ 'X-Error-Format': 'ansi' }),
-});
-assert(ansi.body.includes('\x1b['), 'explicit ANSI consulted ambient NO_COLOR');
-assert(
-  ansi.body.includes('Visitor signals are unavailable'),
-  'ANSI output omitted public prose',
-);
-assert(
-  !ansi.body.includes('Internal visitor failure'),
-  'ANSI output disclosed developer prose',
-);
-assert(
-  wantsAnsi(new Headers({ 'X-Error-Format': 'ansi' })),
-  'server subpath negotiation failed',
-);
-
-assert(
-  parseErrorResponse({ error: { hint: false, message: 'Failed' } }) ===
-    undefined,
-  'strict parsing accepted malformed known fields',
-);
-let invalidStatusRejected = false;
-try {
-  errorResponse({ message: 'Failed', statusCode: 399 });
-} catch (error) {
-  invalidStatusRejected = error instanceof RangeError;
-}
-assert(invalidStatusRejected, 'invalid status was not rejected');
-
-assert(
-  formatError(reconstructed, { format: 'plain' }).includes(
-    'Visitor signals are unavailable',
-  ),
-  'format subpath could not render an error',
-);
-assert(
-  frame('Failed', [hint('Try again'), fix('Retry'), link('https://x.dev')], {
-    format: 'tree',
-  }).includes('╰─▸'),
-  'structured frame sections did not render',
-);
-`;
-
-const utilityFixture = String.raw`
-import { hasCode } from '@vercel/error';
-
-export function isUnavailable(error: unknown): boolean {
-  return hasCode(error, 'unavailable');
-}
-`;
-
-const browserBuildConfig = String.raw`
-export default {
-  clean: true,
-  deps: {
-    alwaysBundle: [/.*/],
-  },
-  entry: ['browser.ts'],
-  format: ['iife'],
-  logLevel: 'error',
-  outDir: 'browser-bundle',
-  platform: 'browser',
-  target: 'es2022',
-};
-`;
-
-const browserFixture = String.raw`
-import * as root from '@vercel/error';
-import * as client from '@vercel/error/client';
-import * as server from '@vercel/error/server';
-import * as format from '@vercel/error/format';
-
-function assert(condition: unknown, message: string): asserts condition {
-  if (!condition) throw new Error(message);
-}
-
-for (const nodeGlobal of ['process', 'Buffer', 'require']) {
-  assert(
-    !(nodeGlobal in globalThis),
-    'Node VM sandbox unexpectedly exposes global ' + nodeGlobal,
-  );
-}
-
-const runtimeExports = {
-  '.': root,
-  './client': client,
-  './server': server,
-  './format': format,
-};
-(globalThis as typeof globalThis & {
-  __vercelErrorExercisedExports?: Record<string, string[]>;
-}).__vercelErrorExercisedExports = Object.fromEntries(
-  Object.entries(runtimeExports).map(([subpath, exports]) => [
-    subpath,
-    Object.keys(exports).sort(),
-  ]),
-);
-
-assert(
-  root.isError(new Error('browser failure')),
-  'isError did not recognize an Error created in the Node VM',
-);
-const acceptsTagForgery = (
-  globalThis as typeof globalThis & {
-    __vercelErrorAcceptsTagForgery: boolean;
-  }
-).__vercelErrorAcceptsTagForgery;
-assert(
-  root.isError({ [Symbol.toStringTag]: 'Error' }) === acceptsTagForgery,
-  'isError did not select the expected recognition branch',
-);
-
-const error = new root.VercelError('DEV_MESSAGE', {
-  code: 'unavailable',
-  public: { message: 'The service is unavailable' },
-  scope: 'browser',
-  statusCode: 503,
-});
-
-const json = server.errorResponse(error);
-assert(
-  json.status === 503,
-  'errorResponse did not map statusCode 503 to response status 503',
-);
-assert(
-  !json.body.includes('DEV_MESSAGE'),
-  'JSON response contains the developer message',
-);
-const parsed = client.parseErrorResponse(JSON.parse(json.body));
-assert(
-  parsed?.error.code === 'unavailable' &&
-    parsed.error.message === 'The service is unavailable',
-  'browser response did not preserve its public identity and message',
-);
-const reconstructed = client.fromErrorResponse(parsed, {
-  statusCode: json.status,
-});
-assert(
-  server.errorResponse(reconstructed).body === json.body,
-  'reconstructed error did not serialize to the same public body',
-);
-assert(
-  format.formatError(reconstructed, { format: 'plain' }).includes(
-    'The service is unavailable',
-  ),
-  'plain format omitted the reconstructed public message',
-);
-
-(globalThis as typeof globalThis & {
-  __vercelErrorBrowserCheckComplete?: boolean;
-}).__vercelErrorBrowserCheckComplete = true;
-`;
 
 await main();

--- a/scripts/verify-packed-package.mjs
+++ b/scripts/verify-packed-package.mjs
@@ -9,7 +9,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { runInNewContext } from 'node:vm';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -17,7 +17,7 @@ const workspace = mkdtempSync(join(tmpdir(), 'vercel-error-packed-'));
 const packDirectory = join(workspace, 'package');
 const consumerDirectory = join(workspace, 'consumer');
 
-function main() {
+async function main() {
   try {
     execFileSync('mkdir', [packDirectory, consumerDirectory]);
     execFileSync('pnpm', ['pack', '--pack-destination', packDirectory], {
@@ -88,7 +88,7 @@ function main() {
       join(consumerDirectory, 'node_modules/@vercel/error/dist'),
     );
     verifyTreeShaking(consumerDirectory);
-    verifyBrowserBundle(consumerDirectory);
+    await verifyBrowserBundle(consumerDirectory);
 
     console.log('Packed package verification passed.');
   } finally {
@@ -215,7 +215,7 @@ function verifyTreeShaking(directory) {
   }
 }
 
-function verifyBrowserBundle(directory) {
+async function verifyBrowserBundle(directory) {
   const tsdown = join(packageRoot, 'node_modules', '.bin', 'tsdown');
   execFileSync(tsdown, ['--config', 'tsdown.browser.config.mjs'], {
     cwd: directory,
@@ -253,6 +253,26 @@ function verifyBrowserBundle(directory) {
     throw new Error('Packed verification runtime has no native Error.isError');
   }
 
+  const installedPackageRoot = join(directory, 'node_modules/@vercel/error');
+  const installedPackage = JSON.parse(
+    readFileSync(join(installedPackageRoot, 'package.json'), 'utf8'),
+  );
+  const expectedRuntimeExports = Object.fromEntries(
+    await Promise.all(
+      Object.entries(installedPackage.exports).map(
+        async ([subpath, target]) => [
+          subpath,
+          Object.keys(
+            await import(
+              pathToFileURL(resolve(installedPackageRoot, target.default))
+            ),
+          ).toSorted(),
+        ],
+      ),
+    ),
+  );
+  const expectedRuntimeExportsJson = JSON.stringify(expectedRuntimeExports);
+
   for (const scenario of [
     { acceptsTagForgery: false, name: 'native Error.isError', setup: '' },
     {
@@ -265,6 +285,7 @@ function verifyBrowserBundle(directory) {
     const sandbox = Object.assign(Object.create(null), {
       __vercelErrorAcceptsTagForgery: scenario.acceptsTagForgery,
       document: Object.freeze({}),
+      location: Object.freeze({ href: 'https://example.com/' }),
       navigator: Object.freeze({ userAgent: 'packed-browser-check' }),
     });
     sandbox.self = sandbox;
@@ -285,6 +306,14 @@ function verifyBrowserBundle(directory) {
     if (sandbox.__vercelErrorBrowserCheckComplete !== true) {
       throw new Error(
         `Browser fixture did not complete in Node VM scenario "${scenario.name}"`,
+      );
+    }
+    if (
+      JSON.stringify(sandbox.__vercelErrorExercisedExports) !==
+      expectedRuntimeExportsJson
+    ) {
+      throw new Error(
+        `Browser fixture does not exercise every packed runtime export in Node VM scenario "${scenario.name}"`,
       );
     }
   }
@@ -550,27 +579,36 @@ for (const nodeGlobal of ['process', 'Buffer', 'require']) {
 }
 
 const runtimeExports = {
-  VercelError,
-  createErrors,
-  errorResponse,
-  fix,
-  formatError,
-  frame,
-  fromErrorResponse,
-  getMessage,
-  getRootCause,
-  hasCode,
-  hint,
-  isError,
-  isErrorLike,
-  isVercelError,
-  link,
-  parseErrorResponse,
-  wantsAnsi,
+  '.': {
+    VercelError,
+    createErrors,
+    getMessage,
+    getRootCause,
+    hasCode,
+    isError,
+    isErrorLike,
+    isVercelError,
+  },
+  './client': { fromErrorResponse, parseErrorResponse },
+  './server': { errorResponse, wantsAnsi },
+  './format': { fix, formatError, frame, hint, link },
 };
-for (const [name, value] of Object.entries(runtimeExports)) {
-  assert(typeof value === 'function', 'browser bundle omitted export ' + name);
+for (const [subpath, exports] of Object.entries(runtimeExports)) {
+  for (const [name, value] of Object.entries(exports)) {
+    assert(
+      typeof value === 'function',
+      'browser bundle omitted export ' + subpath + ':' + name,
+    );
+  }
 }
+(globalThis as typeof globalThis & {
+  __vercelErrorExercisedExports?: Record<string, string[]>;
+}).__vercelErrorExercisedExports = Object.fromEntries(
+  Object.entries(runtimeExports).map(([subpath, exports]) => [
+    subpath,
+    Object.keys(exports).sort(),
+  ]),
+);
 
 assert(
   isError(new Error('browser failure')),
@@ -655,7 +693,7 @@ assert(
   'JSON response contains unexpected top-level fields',
 );
 assert(
-  Object.keys(jsonData.error).join(',') === 'scope,code,message',
+  Object.keys(jsonData.error).sort().join(',') === 'code,message,scope',
   'JSON response contains unexpected error fields',
 );
 assert(
@@ -731,4 +769,4 @@ assert(
 }).__vercelErrorBrowserCheckComplete = true;
 `;
 
-main();
+await main();

--- a/scripts/verify-packed-package.mjs
+++ b/scripts/verify-packed-package.mjs
@@ -553,20 +553,6 @@ import * as client from '@vercel/error/client';
 import * as server from '@vercel/error/server';
 import * as format from '@vercel/error/format';
 
-const {
-  VercelError,
-  createErrors,
-  getMessage,
-  getRootCause,
-  hasCode,
-  isError,
-  isErrorLike,
-  isVercelError,
-} = root;
-const { fromErrorResponse, parseErrorResponse } = client;
-const { errorResponse, wantsAnsi } = server;
-const { fix, formatError, frame, hint, link } = format;
-
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
 }
@@ -579,28 +565,11 @@ for (const nodeGlobal of ['process', 'Buffer', 'require']) {
 }
 
 const runtimeExports = {
-  '.': {
-    VercelError,
-    createErrors,
-    getMessage,
-    getRootCause,
-    hasCode,
-    isError,
-    isErrorLike,
-    isVercelError,
-  },
-  './client': { fromErrorResponse, parseErrorResponse },
-  './server': { errorResponse, wantsAnsi },
-  './format': { fix, formatError, frame, hint, link },
+  '.': root,
+  './client': client,
+  './server': server,
+  './format': format,
 };
-for (const [subpath, exports] of Object.entries(runtimeExports)) {
-  for (const [name, value] of Object.entries(exports)) {
-    assert(
-      typeof value === 'function',
-      'browser bundle omitted export ' + subpath + ':' + name,
-    );
-  }
-}
 (globalThis as typeof globalThis & {
   __vercelErrorExercisedExports?: Record<string, string[]>;
 }).__vercelErrorExercisedExports = Object.fromEntries(
@@ -611,7 +580,7 @@ for (const [subpath, exports] of Object.entries(runtimeExports)) {
 );
 
 assert(
-  isError(new Error('browser failure')),
+  root.isError(new Error('browser failure')),
   'isError did not recognize an Error created in the Node VM',
 );
 const acceptsTagForgery = (
@@ -620,148 +589,44 @@ const acceptsTagForgery = (
   }
 ).__vercelErrorAcceptsTagForgery;
 assert(
-  isError({ [Symbol.toStringTag]: 'Error' }) === acceptsTagForgery,
+  root.isError({ [Symbol.toStringTag]: 'Error' }) === acceptsTagForgery,
   'isError did not select the expected recognition branch',
 );
 
-let plainErrorRejected = false;
-try {
-  errorResponse(new Error('Secret browser failure'));
-} catch (caught) {
-  plainErrorRejected = caught instanceof TypeError;
-}
-assert(
-  plainErrorRejected,
-  'errorResponse did not reject a plain Error with TypeError',
-);
-
-const developerCanaries = [
-  'DEV_MESSAGE',
-  'DEV_NAME',
-  'DEV_REASON',
-  'DEV_HINT',
-  'DEV_FIX',
-  'DEV_LINK',
-  'DEV_REQUEST_ID',
-  'DEV_METADATA',
-  'DEV_ATTRIBUTE',
-  'DEV_CAUSE',
-];
-function assertNoDeveloperCanaries(body: string, formatName: string): void {
-  for (const canary of developerCanaries) {
-    assert(!body.includes(canary), formatName + ' body contains ' + canary);
-  }
-}
-
-const cause = new Error('DEV_CAUSE');
-const errors = createErrors({ scope: 'browser' });
-const error = errors.create('DEV_MESSAGE', {
-  attributes: { diagnostic: 'DEV_ATTRIBUTE' },
-  cause,
+const error = new root.VercelError('DEV_MESSAGE', {
   code: 'unavailable',
-  fix: 'DEV_FIX',
-  hint: 'DEV_HINT',
-  link: 'https://example.com/DEV_LINK',
-  metadata: { diagnostic: 'DEV_METADATA' },
   public: { message: 'The service is unavailable' },
-  reason: 'DEV_REASON',
-  requestId: 'DEV_REQUEST_ID',
+  scope: 'browser',
   statusCode: 503,
 });
-error.name = 'DEV_NAME';
 
-assert(error instanceof VercelError, 'createErrors did not use VercelError');
-assert(hasCode(error, 'unavailable'), 'hasCode did not match the error code');
-assert(isErrorLike(error), 'isErrorLike did not recognize VercelError');
-assert(isVercelError(error), 'isVercelError did not recognize VercelError');
-assert(getMessage(error) === 'DEV_MESSAGE', 'getMessage changed the message');
-assert(getRootCause(error) === cause, 'getRootCause did not return the cause');
-
-const json = errorResponse(error);
+const json = server.errorResponse(error);
 assert(
   json.status === 503,
   'errorResponse did not map statusCode 503 to response status 503',
 );
 assert(
-  json.headers['Content-Type'] === 'application/json',
-  'JSON response content type was not application/json',
+  !json.body.includes('DEV_MESSAGE'),
+  'JSON response contains the developer message',
 );
-assertNoDeveloperCanaries(json.body, 'JSON');
-const jsonData = JSON.parse(json.body);
+const parsed = client.parseErrorResponse(JSON.parse(json.body));
 assert(
-  Object.keys(jsonData).join(',') === 'error',
-  'JSON response contains unexpected top-level fields',
+  parsed?.error.code === 'unavailable' &&
+    parsed.error.message === 'The service is unavailable',
+  'browser response did not preserve its public identity and message',
 );
+const reconstructed = client.fromErrorResponse(parsed, {
+  statusCode: json.status,
+});
 assert(
-  Object.keys(jsonData.error).sort().join(',') === 'code,message,scope',
-  'JSON response contains unexpected error fields',
-);
-assert(
-  jsonData.error.scope === 'browser' &&
-    jsonData.error.code === 'unavailable' &&
-    jsonData.error.message === 'The service is unavailable',
-  'JSON response fields do not match the public error',
-);
-
-const parsed = parseErrorResponse(jsonData);
-assert(
-  parsed?.error.message === 'The service is unavailable',
-  'parseErrorResponse did not return the public message',
-);
-const reconstructed = fromErrorResponse(parsed, { statusCode: json.status });
-assert(
-  reconstructed.message === 'The service is unavailable' &&
-    reconstructed.scope === 'browser' &&
-    reconstructed.code === 'unavailable' &&
-    reconstructed.statusCode === 503 &&
-    reconstructed.public?.message === 'The service is unavailable',
-  'fromErrorResponse did not reconstruct the public response fields',
-);
-assert(
-  errorResponse(reconstructed).body === json.body,
+  server.errorResponse(reconstructed).body === json.body,
   'reconstructed error did not serialize to the same public body',
 );
-
-const ansiHeaders = {
-  get(name: string): string | null {
-    return name === 'x-error-format' ? 'ansi' : null;
-  },
-};
 assert(
-  wantsAnsi(ansiHeaders),
-  'wantsAnsi did not accept x-error-format: ansi',
-);
-const ansi = errorResponse(error, { request: ansiHeaders });
-assert(
-  ansi.headers['Content-Type'] === 'text/plain; charset=utf-8',
-  'ANSI response content type was not text/plain; charset=utf-8',
-);
-assert(
-  ansi.body.includes('\x1b['),
-  'errorResponse did not emit ANSI control sequences',
-);
-assert(
-  ansi.body.includes('The service is unavailable'),
-  'ANSI response body omitted the public message',
-);
-assertNoDeveloperCanaries(ansi.body, 'ANSI');
-
-assert(
-  formatError(reconstructed, { format: 'plain' }).includes(
+  format.formatError(reconstructed, { format: 'plain' }).includes(
     'The service is unavailable',
   ),
   'plain format omitted the reconstructed public message',
-);
-const renderedFrame = frame(
-  'Browser failure',
-  [hint('Try again'), fix('Retry'), link('https://example.com/help')],
-  { format: 'tree' },
-);
-assert(
-  renderedFrame.includes('hint: Try again') &&
-    renderedFrame.includes('fix: Retry') &&
-    renderedFrame.includes('read more: https://example.com/help'),
-  'tree frame omitted a structured section',
 );
 
 (globalThis as typeof globalThis & {

--- a/scripts/verify-packed-package.mjs
+++ b/scripts/verify-packed-package.mjs
@@ -67,6 +67,7 @@ async function main() {
     for (const fixture of [
       'browser.ts',
       'consumer.ts',
+      'tsconfig.browser.json',
       'tsdown.browser.config.mjs',
       'utility.ts',
     ]) {
@@ -81,6 +82,15 @@ async function main() {
       cwd: consumerDirectory,
       stdio: 'inherit',
     });
+    execFileSync(
+      process.execPath,
+      [tsc, '--project', 'tsconfig.browser.json'],
+      {
+        cwd: consumerDirectory,
+        stdio: 'inherit',
+        timeout: 60_000,
+      },
+    );
 
     const runtimeEnvironment = { ...process.env, NO_COLOR: '1' };
     delete runtimeEnvironment.FORCE_COLOR;
@@ -265,16 +275,16 @@ async function verifyBrowserBundle(directory) {
   );
   const expectedRuntimeExports = Object.fromEntries(
     await Promise.all(
-      Object.entries(installedPackage.exports).map(
-        async ([subpath, target]) => [
+      Object.entries(installedPackage.exports)
+        .toSorted(([left], [right]) => left.localeCompare(right))
+        .map(async ([subpath, target]) => [
           subpath,
           Object.keys(
             await import(
               pathToFileURL(resolve(installedPackageRoot, target.default))
             ),
-          ).toSorted(),
-        ],
-      ),
+          ),
+        ]),
     ),
   );
   const expectedRuntimeExportsJson = JSON.stringify(expectedRuntimeExports);
@@ -315,11 +325,11 @@ async function verifyBrowserBundle(directory) {
       );
     }
     if (
-      JSON.stringify(sandbox.__vercelErrorExercisedExports) !==
+      JSON.stringify(sandbox.__vercelErrorRuntimeExportKeys) !==
       expectedRuntimeExportsJson
     ) {
       throw new Error(
-        `Browser fixture does not exercise every packed runtime export in Node VM scenario "${scenario.name}"`,
+        `Browser-platform bundle runtime export keys do not match the installed package in Node VM scenario "${scenario.name}"`,
       );
     }
   }


### PR DESCRIPTION
## Problem

`@vercel/error` promises the same modules work in browsers, workers, edge runtimes, and Node, but the packed-package check only executed the published artifact in Node. Browser-targeted bundling, the `Error.isError` fallback, and basic disclosure behavior could regress without blocking a release.

## Approach

The packed verifier now installs the real tarball, bundles every runtime export and dependency as a browser-platform ES2022 IIFE, and executes it in isolated Node VM contexts without Node globals. Export coverage is compared with the installed package export map, so a new runtime export or subpath fails until the browser fixture includes it.

The fixture runs once with native `Error.isError` and once with the builtin removed. It proves the expected recognition branch ran, completes one disclosure-safe server-to-client response round-trip, calls the format entry point, and reports successful completion in both scenarios. Detailed response, negotiation, reconstruction, and formatting behavior remains in the focused unit tests.

The consumer programs and browser build config are checked-in fixture files, so normal formatting and linting apply before the verifier copies them into its isolated temporary consumer.

## Boundary

This is PR 1 of 3 to strengthen the published contract before migrating front. It verifies browser-targeted output in isolated ECMAScript realms, not a real browser engine or DOM implementation; adding browser automation remains deferred until a browser-specific defect requires it.

This publishes `0.1.3` after merge.