### PR TITLE
fix: return the checked getMessage value and document public APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Patch Changes
 
-- Keep `getMessage()` within its declared string return contract for stateful inputs, and complete generated API documentation for public fields, guards, factories, response data, and formatting types.
+- Read `message` once so `getMessage()` returns the string it checked.
+- Use `Object` in the `getMessage()` JSON fallback when `constructor.name` is unavailable or not a string.
+- Add generated API documentation for public fields, type guards, factories, response data, and formatting types.
 
 ## 0.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Complete generated API documentation for public fields, guards, factories, response data, and formatting types.
+- Keep `getMessage()` within its declared string return contract for stateful inputs, and complete generated API documentation for public fields, guards, factories, response data, and formatting types.
 
 ## 0.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vercel/error
 
+## 0.1.4
+
+### Patch Changes
+
+- Complete generated API documentation for public fields, guards, factories, response data, and formatting types.
+
 ## 0.1.3
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -361,11 +361,11 @@ All utilities below are exported from `@vercel/error`:
 | **@vercel/error**        |                   |
 | `VercelError`            |           1.69 kB |
 | `createErrors`           |           1.91 kB |
-| `isVercelError`          |           1.85 kB |
-| `isError`                |             108 B |
+| `isVercelError`          |           1.83 kB |
+| `isError`                |              92 B |
 | `isErrorLike`            |              85 B |
 | `hasCode`                |             111 B |
-| `getMessage`             |             186 B |
+| `getMessage`             |             187 B |
 | `getRootCause`           |             145 B |
 | **@vercel/error/client** |                   |
 | `fromErrorResponse`      |           1.76 kB |

--- a/README.md
+++ b/README.md
@@ -361,11 +361,11 @@ All utilities below are exported from `@vercel/error`:
 | **@vercel/error**        |                   |
 | `VercelError`            |           1.69 kB |
 | `createErrors`           |           1.91 kB |
-| `isVercelError`          |           1.83 kB |
+| `isVercelError`          |           1.85 kB |
 | `isError`                |             108 B |
 | `isErrorLike`            |              85 B |
 | `hasCode`                |             111 B |
-| `getMessage`             |             170 B |
+| `getMessage`             |             186 B |
 | `getRootCause`           |             145 B |
 | **@vercel/error/client** |                   |
 | `fromErrorResponse`      |           1.76 kB |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/error",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A lightweight toolkit for structured, actionable errors for humans and agents",
   "license": "MIT",
   "author": "Vercel",

--- a/src/create-errors/index.ts
+++ b/src/create-errors/index.ts
@@ -20,10 +20,11 @@ function resolveDocsUrl<TCode extends string>(
 }
 
 /**
- * Per-error options passed to create/raise/report.
- * `scope` is omitted because the factory owns it. Per-error `metadata` and
- * `attributes` shallow-merge over factory defaults, and an explicit `link`
- * takes precedence over `docsBaseUrl`.
+ * Options accepted by `create`, `raise`, and `report`.
+ *
+ * `createErrors` supplies `scope`, so callers cannot set it per error.
+ * Per-error `metadata` and `attributes` shallow-merge over factory defaults.
+ * An explicit per-error `link` overrides a link derived from `docsBaseUrl`.
  */
 export type CreateErrorOptions<TCode extends string = string> = Omit<
   VercelErrorOptions<TCode>,
@@ -31,8 +32,8 @@ export type CreateErrorOptions<TCode extends string = string> = Omit<
 >;
 
 /**
- * Constructor constraint for custom error classes.
- * Any class that extends VercelError and accepts `(message, options?)` is valid.
+ * Type accepted for a custom error class. The class must extend `VercelError`
+ * and accept `(message, options?)`.
  */
 export type VercelErrorConstructor<
   TCode extends string = string,
@@ -62,7 +63,7 @@ export interface ErrorFactory<
 }
 
 /**
- * Shared defaults and diagnostics for {@link createErrors}.
+ * Values and behavior shared by every error from {@link createErrors}.
  *
  * A supplied `ErrorClass` determines the returned subtype. `onReport` runs only
  * for `report`; omission defaults that method to `console.error`.
@@ -89,22 +90,23 @@ export interface CreateErrorsOptions<
    * to skip.
    *
    * Applied only when an error has a `code` and no explicit `link`. A
-   * per-error `link` always wins. This derives developer documentation only;
-   * a client-visible `public.link` must be supplied explicitly. Resolver
+   * per-error `link` always wins. This sets only the developer-facing `link`;
+   * set `public.link` separately for client responses. Resolver
    * exceptions propagate from `create`, `raise`, or `report`.
    */
   docsBaseUrl?: string | ((code: TCode) => string | undefined);
 
-  /** Custom subtype constructor. Required when requesting a custom TError. */
+  /** Custom error class. Required when requesting a custom `TError`. */
   ErrorClass?: VercelErrorConstructor<TCode, TError>;
   /**
-   * Shared flat telemetry values. Per-error keys win during a shallow merge;
-   * the result remains diagnostic and is never sent in error responses.
+   * Factory-wide OpenTelemetry-compatible values. Per-error values replace
+   * factory values with the same keys. The merged attributes are excluded from
+   * error responses.
    */
   attributes?: ErrorAttributes;
   /**
-   * Shared nested diagnostic context. Per-error keys win during a shallow
-   * top-level merge; the result is never sent in error responses.
+   * Factory-wide nested debugging data. Per-error keys replace factory values
+   * with the same top-level keys. The merged data is excluded from responses.
    */
   metadata?: ErrorMetadata;
 

--- a/src/create-errors/index.ts
+++ b/src/create-errors/index.ts
@@ -21,7 +21,9 @@ function resolveDocsUrl<TCode extends string>(
 
 /**
  * Per-error options passed to create/raise/report.
- * `scope` is omitted because it's the factory's identity.
+ * `scope` is omitted because the factory owns it. Per-error `metadata` and
+ * `attributes` shallow-merge over factory defaults, and an explicit `link`
+ * takes precedence over `docsBaseUrl`.
  */
 export type CreateErrorOptions<TCode extends string = string> = Omit<
   VercelErrorOptions<TCode>,
@@ -51,7 +53,10 @@ export interface ErrorFactory<
   create(message: string, options?: CreateErrorOptions<TCode>): TError;
   /** Create and throw an error without reporting it. */
   raise(message: string, options?: CreateErrorOptions<TCode>): never;
-  /** Create, synchronously report, and return the same error. */
+  /**
+   * Create, synchronously report, and return the same error. Without
+   * `onReport`, reporting uses `console.error`; reporter exceptions propagate.
+   */
   report(message: string, options?: CreateErrorOptions<TCode>): TError;
 }
 
@@ -84,13 +89,22 @@ export interface CreateErrorsOptions<
    *
    * Applied only when an error has a `code` and no explicit `link`. A
    * per-error `link` always wins. This derives developer documentation only;
-   * a client-visible `public.link` must be supplied explicitly.
+   * a client-visible `public.link` must be supplied explicitly. Resolver
+   * exceptions propagate from `create`, `raise`, or `report`.
    */
   docsBaseUrl?: string | ((code: TCode) => string | undefined);
 
   /** Custom subtype constructor. Required when requesting a custom TError. */
   ErrorClass?: VercelErrorConstructor<TCode, TError>;
+  /**
+   * Shared flat telemetry values. Per-error keys win during a shallow merge;
+   * the result remains diagnostic and is never sent in error responses.
+   */
   attributes?: ErrorAttributes;
+  /**
+   * Shared nested diagnostic context. Per-error keys win during a shallow
+   * top-level merge; the result is never sent in error responses.
+   */
   metadata?: ErrorMetadata;
 
   /**
@@ -143,6 +157,10 @@ export function createErrors<
     readonly ErrorClass: VercelErrorConstructor<TCode, TError>;
   },
 ): ErrorFactory<TCode, TError>;
+/**
+ * Create a factory that returns `VercelError<TCode>` instances. Options are
+ * optional; without `onReport`, `report()` uses `console.error`.
+ */
 export function createErrors<TCode extends string = string>(
   options?: CreateErrorsOptions<TCode, VercelError<TCode>>,
 ): ErrorFactory<TCode, VercelError<TCode>>;

--- a/src/create-errors/index.ts
+++ b/src/create-errors/index.ts
@@ -54,8 +54,9 @@ export interface ErrorFactory<
   /** Create and throw an error without reporting it. */
   raise(message: string, options?: CreateErrorOptions<TCode>): never;
   /**
-   * Create, synchronously report, and return the same error. Without
-   * `onReport`, reporting uses `console.error`; reporter exceptions propagate.
+   * Create an error, report it synchronously through `onReport` or
+   * `console.error`, then return the same error. If reporting throws, this
+   * method does not return.
    */
   report(message: string, options?: CreateErrorOptions<TCode>): TError;
 }
@@ -108,9 +109,9 @@ export interface CreateErrorsOptions<
   metadata?: ErrorMetadata;
 
   /**
-   * Synchronous callback used only by `report` after the error is created.
-   * Exceptions propagate and replace the return value. Async callbacks are
-   * rejected by the `undefined` return type.
+   * Called synchronously after `report` creates an error. It is not called by
+   * `create` or `raise`. Exceptions propagate. The callback must return
+   * `undefined`, so TypeScript rejects async callbacks.
    */
   onReport?: (error: TError) => undefined;
 }

--- a/src/create-errors/index.ts
+++ b/src/create-errors/index.ts
@@ -20,11 +20,8 @@ function resolveDocsUrl<TCode extends string>(
 }
 
 /**
- * Options accepted by `create`, `raise`, and `report`.
- *
- * `createErrors` supplies `scope`, so callers cannot set it per error.
- * Per-error `metadata` and `attributes` shallow-merge over factory defaults.
- * An explicit per-error `link` overrides a link derived from `docsBaseUrl`.
+ * Per-error options. The factory supplies `scope`; `metadata` and `attributes`
+ * merge over factory values, and an explicit `link` overrides `docsBaseUrl`.
  */
 export type CreateErrorOptions<TCode extends string = string> = Omit<
   VercelErrorOptions<TCode>,
@@ -41,10 +38,7 @@ export type VercelErrorConstructor<
 > = new (message: string, options?: VercelErrorOptions<TCode>) => TError;
 
 /**
- * Typed methods returned by {@link createErrors}.
- *
- * `create` returns an error without reporting, `raise` throws without
- * reporting, and `report` creates one error, calls `onReport`, then returns it.
+ * Methods returned by {@link createErrors}: create, throw, or report an error.
  */
 export interface ErrorFactory<
   TCode extends string = string,
@@ -54,80 +48,47 @@ export interface ErrorFactory<
   create(message: string, options?: CreateErrorOptions<TCode>): TError;
   /** Create and throw an error without reporting it. */
   raise(message: string, options?: CreateErrorOptions<TCode>): never;
-  /**
-   * Create an error, report it synchronously through `onReport` or
-   * `console.error`, then return the same error. If reporting throws, this
-   * method does not return.
-   */
+  /** Create, report, and return one error. Reporting errors propagate. */
   report(message: string, options?: CreateErrorOptions<TCode>): TError;
 }
 
 /**
- * Values and behavior shared by every error from {@link createErrors}.
- *
- * A supplied `ErrorClass` determines the returned subtype. `onReport` runs only
- * for `report`; omission defaults that method to `console.error`.
+ * Values shared by every error from {@link createErrors}. `ErrorClass` changes
+ * the returned class. `onReport` runs only for `report` and defaults to
+ * `console.error`.
  */
 export interface CreateErrorsOptions<
   TCode extends string = string,
   TError extends VercelError<TCode> = VercelError<TCode>,
 > {
-  /**
-   * Namespace injected into every error this factory produces.
-   * Optional. Provide it only when a scope is useful, such as grouping errors
-   * by service or subsystem. When omitted, errors have no `scope`.
-   */
+  /** Scope assigned to every error; omission leaves it undefined. */
   scope?: string;
 
   /**
-   * Base URL or resolver for documentation links. When a string, the error's
-   * `code` is appended verbatim as a path segment
-   * (e.g. `"https://vercel.com/docs/errors"` plus code `"pool_exhausted"` gives
-   * `"https://vercel.com/docs/errors/pool_exhausted"`). Trailing slashes on a
-   * string base are trimmed before joining. The code is not transformed, so
-   * use a function base if you need to change its case or shape.
-   * When a function, it receives the `code` and returns a URL, or `undefined`
-   * to skip.
-   *
-   * Applied only when an error has a `code` and no explicit `link`. A
-   * per-error `link` always wins. This sets only the developer-facing `link`;
-   * set `public.link` separately for client responses. Resolver
-   * exceptions propagate from `create`, `raise`, or `report`.
+   * Base URL or function used to create a developer-facing `link` from `code`.
+   * String bases lose trailing slashes before the unchanged code is appended.
+   * An explicit per-error `link` wins. Set `public.link` separately for client
+   * responses. Function errors propagate.
    */
   docsBaseUrl?: string | ((code: TCode) => string | undefined);
 
   /** Custom error class. Required when requesting a custom `TError`. */
   ErrorClass?: VercelErrorConstructor<TCode, TError>;
-  /**
-   * Factory-wide OpenTelemetry-compatible values. Per-error values replace
-   * factory values with the same keys. The merged attributes are excluded from
-   * error responses.
-   */
+  /** Shared attributes; per-error keys win and responses exclude the result. */
   attributes?: ErrorAttributes;
-  /**
-   * Factory-wide nested debugging data. Per-error keys replace factory values
-   * with the same top-level keys. The merged data is excluded from responses.
-   */
+  /** Shared metadata; per-error top-level keys win and responses exclude it. */
   metadata?: ErrorMetadata;
 
   /**
-   * Called synchronously after `report` creates an error. It is not called by
-   * `create` or `raise`. Exceptions propagate. The callback must return
-   * `undefined`, so TypeScript rejects async callbacks.
+   * Called by `report` after creating the error. Exceptions propagate. Must
+   * return `undefined`, so TypeScript rejects async callbacks.
    */
   onReport?: (error: TError) => undefined;
 }
 
 /**
- * Create an error factory with type-safe error codes.
- *
- * Always returns `{ create, raise, report }`.
- * `scope` is optional. Provide it only when you want to group errors by a
- * namespace. When `docsBaseUrl` is set, each error's `link` is derived from
- * its `code`, unless you pass an explicit `link`.
- * When no `onReport` callback is provided, `report` defaults to `console.error`.
- * When `ErrorClass` is provided, all errors are instances of that class.
- * `create` and `raise` never report automatically.
+ * Create a typed factory. `create` and `raise` do not report; `report` uses
+ * `onReport` or `console.error`.
  *
  * @example
  * ```ts
@@ -160,10 +121,7 @@ export function createErrors<
     readonly ErrorClass: VercelErrorConstructor<TCode, TError>;
   },
 ): ErrorFactory<TCode, TError>;
-/**
- * Create a factory that returns `VercelError<TCode>` instances. Options are
- * optional; without `onReport`, `report()` uses `console.error`.
- */
+/** Create a factory returning `VercelError<TCode>` instances. */
 export function createErrors<TCode extends string = string>(
   options?: CreateErrorsOptions<TCode, VercelError<TCode>>,
 ): ErrorFactory<TCode, VercelError<TCode>>;

--- a/src/error-response-data/index.ts
+++ b/src/error-response-data/index.ts
@@ -20,10 +20,11 @@ const RESPONSE_IDENTITY_FIELDS = ['scope', 'code'] as const;
  * Normalized structured data for client-facing errors.
  *
  * The data feeds JSON serialization and ANSI rendering. It excludes status,
- * request ID, metadata, attributes, cause, stack, and developer name. Shape
- * validation does not authenticate the producer or authorize acting on its
- * prose, fixes, or links. `error.message` must be nonblank. Pass unknown input
- * to `parseErrorResponse` from `@vercel/error/client` before reconstruction.
+ * request ID, metadata, attributes, cause, stack, and error name.
+ * `parseErrorResponse` validates this shape only; it does not verify who
+ * produced the data or whether its recovery guidance is safe to follow.
+ * `error.message` must be nonblank. Pass unknown input to
+ * `parseErrorResponse` from `@vercel/error/client` before reconstruction.
  */
 export interface ErrorResponseData {
   readonly error: {
@@ -37,9 +38,9 @@ export interface ErrorResponseData {
     readonly reason?: string;
     /** Optional client-facing investigation advice. */
     readonly hint?: string;
-    /** Optional client-facing recovery guidance. */
+    /** Optional client-facing recovery guidance; it does not authorize action. */
     readonly fix?: string;
-    /** Optional client-facing documentation URL. */
+    /** Optional client-facing URL; verify its producer before following it. */
     readonly link?: string;
   };
 }
@@ -125,9 +126,9 @@ export function buildErrorResponseData(
  *
  * Unknown fields are ignored for additive compatibility. A missing or blank
  * message, or any present known field with the wrong type, rejects the entire
- * value and returns `undefined`. A parsed response remains untrusted data;
- * applications must authenticate its producer and authorize suggested actions.
- * Accessors and Proxy traps in unknown input may execute, and their exceptions
+ * value and returns `undefined`. Successful parsing validates field shape only;
+ * it does not verify who produced the data or whether suggested actions are
+ * safe to perform. Accessors and Proxy traps may run, and their exceptions
  * propagate instead of returning `undefined`.
  */
 export function parseErrorResponse(
@@ -156,12 +157,12 @@ export function parseErrorResponse(
  * Reconstruct a VercelError from validated upstream ErrorResponseData.
  *
  * Response identity populates `scope` and `code`. Response prose populates the
- * developer fields and is also stored under `public`, so a later
- * `errorResponse()` call sends that identity and prose again. Status, cause,
- * request ID, metadata, and attributes remain caller-owned. Validation does
- * not authenticate the producer, make the fields safe for another recipient,
- * or authorize following fixes and links. Pass unknown input through
- * {@link parseErrorResponse} before calling this function.
+ * developer fields and `public`, so a later `errorResponse()` call includes the
+ * same identity and prose. Status, cause, request ID, metadata, and attributes
+ * come from `options`. This function does not verify who produced `data`.
+ * Review its fields before forwarding them to another recipient, and decide
+ * independently whether to follow fixes or links. Pass unknown input through
+ * {@link parseErrorResponse} first.
  */
 export function fromErrorResponse(
   data: ErrorResponseData,

--- a/src/error-response-data/index.ts
+++ b/src/error-response-data/index.ts
@@ -17,16 +17,10 @@ const GENERIC_PUBLIC_MESSAGE = 'An error occurred.';
 const RESPONSE_IDENTITY_FIELDS = ['scope', 'code'] as const;
 
 /**
- * Client-facing error identity and public details shared by JSON and ANSI
- * response bodies.
- *
- * This data excludes the concrete HTTP status, request ID, metadata,
- * attributes, cause, stack, and error name. `error.message` must contain
- * non-whitespace text. Pass unknown input to `parseErrorResponse` from
- * `@vercel/error/client` before reconstruction.
- *
- * Successful parsing confirms field shapes only. It does not establish where
- * the data came from or whether its recovery guidance should be followed.
+ * Client-facing fields shared by JSON and ANSI responses. Excludes status,
+ * request ID, metadata, attributes, cause, stack, and error name. `message`
+ * must contain non-whitespace text. Use `parseErrorResponse` from
+ * `@vercel/error/client` before using unknown data.
  */
 export interface ErrorResponseData {
   readonly error: {
@@ -58,11 +52,8 @@ interface PublicErrorInput extends PublicErrorDetails {
 }
 
 /**
- * Local values added when reconstructing an upstream response.
- *
- * `statusCode` should normally come from the observed HTTP response because
- * `ErrorResponseData` does not contain it. `cause`, `requestId`, `metadata`,
- * and `attributes` add debugging data owned by the receiving application.
+ * Values added during reconstruction. Set `statusCode` from the HTTP response;
+ * the remaining options stay local to the reconstructed error.
  */
 export type FromErrorResponseOptions = Pick<
   VercelErrorOptions,
@@ -72,12 +63,9 @@ export type FromErrorResponseOptions = Pick<
 /**
  * Build client-facing response data from an error or public input.
  *
- * Tagged values are checked before flat input. An invalid tagged value throws
- * instead of being treated as public data. Untagged values with `name` or
- * `stack` also throw. Errors without `public` details receive a fixed generic
- * message instead of the developer-facing message. Each response field is
- * copied from the same property read that was checked, so a getter cannot pass
- * validation with one value and return another.
+ * Invalid tagged values and untagged values with `name` or `stack` throw.
+ * Errors without `public` use a generic message. Each response field is copied
+ * from the same property read that was checked.
  */
 export function buildErrorResponseData(
   source: VercelErrorLike | PublicErrorInput,
@@ -124,14 +112,10 @@ export function buildErrorResponseData(
 /**
  * Parse unknown data as `ErrorResponseData`.
  *
- * Returns `undefined` unless `data.error` is a non-array object with a nonblank
- * string `message` and every present known optional field is a string. Unknown
- * fields are ignored.
- *
- * Successful parsing confirms field shapes only. It does not establish where
- * the data came from or whether suggested actions should be performed.
- * Property reads may invoke accessors or Proxy traps; their exceptions
- * propagate instead of returning `undefined`.
+ * Returns `undefined` unless `data.error` has a nonblank string `message` and
+ * string values for every known optional field. Unknown fields are ignored.
+ * This checks field types, not who produced the data or whether its guidance is
+ * safe. Property-access exceptions propagate.
  */
 export function parseErrorResponse(
   data?: unknown,
@@ -158,14 +142,10 @@ export function parseErrorResponse(
 /**
  * Reconstruct a `VercelError` from validated `ErrorResponseData`.
  *
- * Copies `scope` and `code` to the error identity. Copies `message`, `reason`,
- * `hint`, `fix`, and `link` to both the developer-facing fields and `public`, so
- * a later `errorResponse()` call includes the same client-facing data. `options`
- * supplies the status mapping, cause, request ID, metadata, and attributes.
- *
- * Pass unknown input through {@link parseErrorResponse} first. This function
- * does not establish where `data` came from. Review it before sending it to a
- * different audience or following its recovery guidance.
+ * Copies response fields to the matching developer and `public` fields.
+ * `options` supplies status, cause, request ID, metadata, and attributes. Parse
+ * unknown input first. Review the data before sending it to another audience or
+ * following its guidance.
  */
 export function fromErrorResponse(
   data: ErrorResponseData,

--- a/src/error-response-data/index.ts
+++ b/src/error-response-data/index.ts
@@ -26,13 +26,21 @@ const RESPONSE_IDENTITY_FIELDS = ['scope', 'code'] as const;
  * through {@link parseErrorResponse} before reconstruction.
  */
 export interface ErrorResponseData {
+  /** Canonical Vercel error envelope shared by JSON and ANSI responses. */
   readonly error: {
+    /** Optional disclosed identity namespace. */
     readonly scope?: string;
+    /** Optional disclosed stable error code. */
     readonly code?: string;
+    /** Required nonblank client-facing description. */
     readonly message: string;
+    /** Optional client-facing explanation. */
     readonly reason?: string;
+    /** Optional client-facing advisory guidance. */
     readonly hint?: string;
+    /** Optional remediation suggestion; it does not authorize action. */
     readonly fix?: string;
+    /** Optional client link; it does not establish producer trust or authority. */
     readonly link?: string;
   };
 }
@@ -50,6 +58,9 @@ interface PublicErrorInput extends PublicErrorDetails {
 /**
  * Caller-owned context accepted while reconstructing an upstream response.
  * Response identity and prose always win and cannot be overridden here.
+ * `statusCode` should normally come from the observed HTTP response because
+ * status is not part of `ErrorResponseData`; all other fields add local
+ * diagnostic context.
  */
 export type FromErrorResponseOptions = Pick<
   VercelErrorOptions,
@@ -117,6 +128,8 @@ export function buildErrorResponseData(
  * message, or any present known field with the wrong type, rejects the entire
  * value and returns `undefined`. A parsed response remains untrusted data;
  * applications must authenticate its producer and authorize suggested actions.
+ * Accessors and Proxy traps in unknown input may execute, and their exceptions
+ * propagate instead of returning `undefined`.
  */
 export function parseErrorResponse(
   data?: unknown,
@@ -148,7 +161,8 @@ export function parseErrorResponse(
  * `errorResponse()` call sends that identity and prose again. Status, cause,
  * request ID, metadata, and attributes remain caller-owned. Validation does
  * not authenticate the producer, make the fields safe for another recipient,
- * or authorize following fixes and links.
+ * or authorize following fixes and links. Pass unknown input through
+ * {@link parseErrorResponse} before calling this function.
  */
 export function fromErrorResponse(
   data: ErrorResponseData,

--- a/src/error-response-data/index.ts
+++ b/src/error-response-data/index.ts
@@ -17,38 +17,40 @@ const GENERIC_PUBLIC_MESSAGE = 'An error occurred.';
 const RESPONSE_IDENTITY_FIELDS = ['scope', 'code'] as const;
 
 /**
- * Normalized structured data for client-facing errors.
+ * Client-facing error identity and public details shared by JSON and ANSI
+ * response bodies.
  *
- * The data feeds JSON serialization and ANSI rendering. It excludes status,
- * request ID, metadata, attributes, cause, stack, and error name.
- * `parseErrorResponse` validates this shape only; it does not verify who
- * produced the data or whether its recovery guidance is safe to follow.
- * `error.message` must be nonblank. Pass unknown input to
- * `parseErrorResponse` from `@vercel/error/client` before reconstruction.
+ * This data excludes the concrete HTTP status, request ID, metadata,
+ * attributes, cause, stack, and error name. `error.message` must contain
+ * non-whitespace text. Pass unknown input to `parseErrorResponse` from
+ * `@vercel/error/client` before reconstruction.
+ *
+ * Successful parsing confirms field shapes only. It does not establish where
+ * the data came from or whether its recovery guidance should be followed.
  */
 export interface ErrorResponseData {
   readonly error: {
-    /** Optional error scope included in the response. */
+    /** Client-visible namespace for the error. */
     readonly scope?: string;
-    /** Optional stable error code included in the response. */
+    /** Client-visible stable error code. */
     readonly code?: string;
-    /** Client-facing description containing non-whitespace text. */
+    /** Client-facing summary containing non-whitespace text. */
     readonly message: string;
-    /** Optional client-facing explanation of why the error occurred. */
+    /** Client-facing explanation of why the error occurred. */
     readonly reason?: string;
-    /** Optional client-facing investigation advice. */
+    /** Client-facing investigation advice. */
     readonly hint?: string;
-    /** Optional client-facing recovery guidance; it does not authorize action. */
+    /** Client-facing recovery guidance. */
     readonly fix?: string;
-    /** Optional client-facing URL; verify its producer before following it. */
+    /** Client-facing documentation URL. */
     readonly link?: string;
   };
 }
 
 /**
  * Public details and identity accepted while building response data.
- * Every prose field is approved for client disclosure; explicitly `undefined`
- * optional fields are omitted.
+ * Every text field is approved for clients. Optional fields set to `undefined`
+ * are omitted.
  */
 interface PublicErrorInput extends PublicErrorDetails {
   readonly scope?: string;
@@ -56,11 +58,11 @@ interface PublicErrorInput extends PublicErrorDetails {
 }
 
 /**
- * Local context added when reconstructing an upstream response.
+ * Local values added when reconstructing an upstream response.
  *
  * `statusCode` should normally come from the observed HTTP response because
  * `ErrorResponseData` does not contain it. `cause`, `requestId`, `metadata`,
- * and `attributes` remain local diagnostic context.
+ * and `attributes` add debugging data owned by the receiving application.
  */
 export type FromErrorResponseOptions = Pick<
   VercelErrorOptions,
@@ -68,16 +70,14 @@ export type FromErrorResponseOptions = Pick<
 >;
 
 /**
- * Build normalized client-facing response data from an error or public input.
+ * Build client-facing response data from an error or public input.
  *
- * Tagged values are classified before flat input. A tagged malformed value is
- * rejected instead of being reinterpreted as explicitly public data. Untagged
- * values carrying `name` or `stack` are treated as Error-like and rejected.
- * Errors without approved `public` details receive a fixed generic message;
- * developer prose is never used as a fallback. Every disclosed field is
- * serialized from a single validated read, so a getter cannot pass validation
- * with one value and serialize another; only validated strings reach the
- * result.
+ * Tagged values are checked before flat input. An invalid tagged value throws
+ * instead of being treated as public data. Untagged values with `name` or
+ * `stack` also throw. Errors without `public` details receive a fixed generic
+ * message instead of the developer-facing message. Each response field is
+ * copied from the same property read that was checked, so a getter cannot pass
+ * validation with one value and return another.
  */
 export function buildErrorResponseData(
   source: VercelErrorLike | PublicErrorInput,
@@ -122,13 +122,15 @@ export function buildErrorResponseData(
 }
 
 /**
- * Parse unknown data as the canonical ErrorResponseData shape.
+ * Parse unknown data as `ErrorResponseData`.
  *
- * Unknown fields are ignored for additive compatibility. A missing or blank
- * message, or any present known field with the wrong type, rejects the entire
- * value and returns `undefined`. Successful parsing validates field shape only;
- * it does not verify who produced the data or whether suggested actions are
- * safe to perform. Accessors and Proxy traps may run, and their exceptions
+ * Returns `undefined` unless `data.error` is a non-array object with a nonblank
+ * string `message` and every present known optional field is a string. Unknown
+ * fields are ignored.
+ *
+ * Successful parsing confirms field shapes only. It does not establish where
+ * the data came from or whether suggested actions should be performed.
+ * Property reads may invoke accessors or Proxy traps; their exceptions
  * propagate instead of returning `undefined`.
  */
 export function parseErrorResponse(
@@ -154,15 +156,16 @@ export function parseErrorResponse(
 }
 
 /**
- * Reconstruct a VercelError from validated upstream ErrorResponseData.
+ * Reconstruct a `VercelError` from validated `ErrorResponseData`.
  *
- * Response identity populates `scope` and `code`. Response prose populates the
- * developer fields and `public`, so a later `errorResponse()` call includes the
- * same identity and prose. Status, cause, request ID, metadata, and attributes
- * come from `options`. This function does not verify who produced `data`.
- * Review its fields before forwarding them to another recipient, and decide
- * independently whether to follow fixes or links. Pass unknown input through
- * {@link parseErrorResponse} first.
+ * Copies `scope` and `code` to the error identity. Copies `message`, `reason`,
+ * `hint`, `fix`, and `link` to both the developer-facing fields and `public`, so
+ * a later `errorResponse()` call includes the same client-facing data. `options`
+ * supplies the status mapping, cause, request ID, metadata, and attributes.
+ *
+ * Pass unknown input through {@link parseErrorResponse} first. This function
+ * does not establish where `data` came from. Review it before sending it to a
+ * different audience or following its recovery guidance.
  */
 export function fromErrorResponse(
   data: ErrorResponseData,

--- a/src/error-response-data/index.ts
+++ b/src/error-response-data/index.ts
@@ -23,24 +23,23 @@ const RESPONSE_IDENTITY_FIELDS = ['scope', 'code'] as const;
  * request ID, metadata, attributes, cause, stack, and developer name. Shape
  * validation does not authenticate the producer or authorize acting on its
  * prose, fixes, or links. `error.message` must be nonblank. Pass unknown input
- * through {@link parseErrorResponse} before reconstruction.
+ * to `parseErrorResponse` from `@vercel/error/client` before reconstruction.
  */
 export interface ErrorResponseData {
-  /** Canonical Vercel error envelope shared by JSON and ANSI responses. */
   readonly error: {
-    /** Optional disclosed identity namespace. */
+    /** Optional error scope included in the response. */
     readonly scope?: string;
-    /** Optional disclosed stable error code. */
+    /** Optional stable error code included in the response. */
     readonly code?: string;
-    /** Required nonblank client-facing description. */
+    /** Client-facing description containing non-whitespace text. */
     readonly message: string;
-    /** Optional client-facing explanation. */
+    /** Optional client-facing explanation of why the error occurred. */
     readonly reason?: string;
-    /** Optional client-facing advisory guidance. */
+    /** Optional client-facing investigation advice. */
     readonly hint?: string;
-    /** Optional remediation suggestion; it does not authorize action. */
+    /** Optional client-facing recovery guidance. */
     readonly fix?: string;
-    /** Optional client link; it does not establish producer trust or authority. */
+    /** Optional client-facing documentation URL. */
     readonly link?: string;
   };
 }
@@ -56,11 +55,11 @@ interface PublicErrorInput extends PublicErrorDetails {
 }
 
 /**
- * Caller-owned context accepted while reconstructing an upstream response.
- * Response identity and prose always win and cannot be overridden here.
+ * Local context added when reconstructing an upstream response.
+ *
  * `statusCode` should normally come from the observed HTTP response because
- * status is not part of `ErrorResponseData`; all other fields add local
- * diagnostic context.
+ * `ErrorResponseData` does not contain it. `cause`, `requestId`, `metadata`,
+ * and `attributes` remain local diagnostic context.
  */
 export type FromErrorResponseOptions = Pick<
   VercelErrorOptions,

--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -23,11 +23,12 @@ export type FrameSection =
 /**
  * Render developer-facing error fields as a sanitized terminal frame.
  *
- * Control characters are removed, CRLF is normalized, and continuation lines
- * are prefixed by the renderer. This output may contain developer-only details;
- * use `errorResponse()` from `@vercel/error/server` for client-safe transport.
- * `format` defaults to `auto`; see {@link ErrorFormat}. Accessors and Proxy traps
- * on structural input may execute, and their exceptions propagate.
+ * ANSI escapes, terminal controls other than tabs and line feeds, Unicode line
+ * separators, and bare carriage returns are removed. CRLF is normalized, and
+ * continuation lines are prefixed by the renderer. This output may contain
+ * developer-facing text; use `errorResponse()` from `@vercel/error/server` for
+ * client-safe transport. `format` defaults to `auto`; see {@link ErrorFormat}.
+ * Accessors and Proxy traps on structural input may run and throw.
  */
 export function formatError(
   error: VercelErrorLike,
@@ -65,10 +66,11 @@ export function formatError(
  *
  * `null`, `undefined`, `false`, and empty string sections are omitted. String
  * sections remain unlabeled; structured sections receive the label and style
- * for their `kind`. Malformed objects with ordinary data properties throw
- * `TypeError`. Accessors and Proxy traps may execute during validation, and
- * their exceptions propagate. `format` defaults to `auto`; see
- * {@link ErrorFormat}.
+ * for their `kind`. At runtime, an object section throws `TypeError` unless
+ * `kind` is `hint`, `fix`, or `link` and `text` is a string. Reading these
+ * properties may invoke accessors or Proxy traps, and their exceptions
+ * propagate. Stateful accessors may change values between validation and
+ * rendering. `format` defaults to `auto`; see {@link ErrorFormat}.
  */
 export function frame(
   header: string,

--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -11,13 +11,9 @@ import type { VercelErrorLike } from '../types';
 export type ErrorFormat = 'auto' | 'plain' | 'tree' | 'ansi';
 
 /**
- * Content accepted by {@link frame}.
- *
- * A string renders as an unlabeled detail. A structured section selects the
- * `hint`, `fix`, or `link` label, its ANSI style, and an arrow connector when
- * connectors are enabled. The renderer does not infer a section kind from a
- * string prefix. Use {@link hint}, {@link fix}, and {@link link} to create
- * structured sections.
+ * Content accepted by {@link frame}. Strings are unlabeled. Structured values
+ * select the `hint`, `fix`, or `link` label and style; string prefixes are not
+ * parsed. Use the matching helper to create a structured section.
  */
 export type FrameSection =
   | string
@@ -28,13 +24,9 @@ export type FrameSection =
 /**
  * Render developer-facing error fields as a terminal frame.
  *
- * ANSI escapes, terminal controls other than tabs and line feeds, Unicode line
- * separators, and bare carriage returns are removed. CRLF is normalized, and
- * continuation lines are prefixed by the renderer. The output may include
- * developer-facing text. To create an HTTP response from public error details,
- * use `errorResponse()` from `@vercel/error/server`. `format` defaults to
- * `auto`; see {@link ErrorFormat}. Reading the input may invoke accessors or
- * Proxy traps, and their exceptions propagate.
+ * Removes unsafe terminal controls and prefixes every continuation line. May
+ * include developer text; use `errorResponse()` for client output. `format`
+ * defaults to `auto`. Property-access exceptions propagate.
  */
 export function formatError(
   error: VercelErrorLike,
@@ -70,13 +62,10 @@ export function formatError(
 /**
  * Render a header and optional sections as a terminal frame.
  *
- * Omits `null`, `undefined`, `false`, and empty string sections. String sections
- * remain unlabeled. Structured sections use the label and style for their
- * `kind`. An object section with an invalid `kind` or non-string `text` throws
- * `TypeError`.
- *
- * Reading a structured section may invoke accessors or Proxy traps, and their
- * exceptions propagate. `format` defaults to `auto`; see {@link ErrorFormat}.
+ * Omits `null`, `undefined`, `false`, and empty strings. Strings are unlabeled;
+ * structured sections use their `kind` label and style. Invalid objects throw
+ * `TypeError`. `format` defaults to `auto`; property-access exceptions
+ * propagate.
  */
 export function frame(
   header: string,

--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -1,18 +1,23 @@
 import type { VercelErrorLike } from '../types';
 
 /**
- * Rendering preset for error frames. `auto` checks `NO_COLOR`, then
- * `FORCE_COLOR`, then TTY state; any defined environment value counts as
- * present. `plain` uses indentation, `tree` adds Unicode connectors, and
- * `ansi` adds connectors and ANSI styling without reading ambient state.
+ * Terminal rendering preset.
+ *
+ * `auto` checks `NO_COLOR`, then `FORCE_COLOR`, then `process.stdout.isTTY`.
+ * An environment variable counts as present even when its value is empty.
+ * `plain` uses indentation, `tree` adds Unicode connectors, and `ansi` adds
+ * connectors and ANSI styling without reading the environment or TTY state.
  */
 export type ErrorFormat = 'auto' | 'plain' | 'tree' | 'ansi';
 
 /**
- * A section accepted by {@link frame}. Strings render as unlabeled details.
- * Structured sections add the label, connector, and style for their `kind`.
- * Rendering sanitizes all text; prefixes in string sections are not parsed.
- * Use {@link hint}, {@link fix}, and {@link link} to create structured sections.
+ * Content accepted by {@link frame}.
+ *
+ * A string renders as an unlabeled detail. A structured section selects the
+ * `hint`, `fix`, or `link` label, its ANSI style, and an arrow connector when
+ * connectors are enabled. The renderer does not infer a section kind from a
+ * string prefix. Use {@link hint}, {@link fix}, and {@link link} to create
+ * structured sections.
  */
 export type FrameSection =
   | string
@@ -21,14 +26,15 @@ export type FrameSection =
   | { readonly kind: 'link'; readonly text: string };
 
 /**
- * Render developer-facing error fields as a sanitized terminal frame.
+ * Render developer-facing error fields as a terminal frame.
  *
  * ANSI escapes, terminal controls other than tabs and line feeds, Unicode line
  * separators, and bare carriage returns are removed. CRLF is normalized, and
- * continuation lines are prefixed by the renderer. This output may contain
- * developer-facing text; use `errorResponse()` from `@vercel/error/server` for
- * client-safe transport. `format` defaults to `auto`; see {@link ErrorFormat}.
- * Accessors and Proxy traps on structural input may run and throw.
+ * continuation lines are prefixed by the renderer. The output may include
+ * developer-facing text. To create an HTTP response from public error details,
+ * use `errorResponse()` from `@vercel/error/server`. `format` defaults to
+ * `auto`; see {@link ErrorFormat}. Reading the input may invoke accessors or
+ * Proxy traps, and their exceptions propagate.
  */
 export function formatError(
   error: VercelErrorLike,
@@ -62,15 +68,15 @@ export function formatError(
 }
 
 /**
- * Render a header and optional sections as a sanitized terminal frame.
+ * Render a header and optional sections as a terminal frame.
  *
- * `null`, `undefined`, `false`, and empty string sections are omitted. String
- * sections remain unlabeled; structured sections receive the label and style
- * for their `kind`. At runtime, an object section throws `TypeError` unless
- * `kind` is `hint`, `fix`, or `link` and `text` is a string. Reading these
- * properties may invoke accessors or Proxy traps, and their exceptions
- * propagate. Stateful accessors may change values between validation and
- * rendering. `format` defaults to `auto`; see {@link ErrorFormat}.
+ * Omits `null`, `undefined`, `false`, and empty string sections. String sections
+ * remain unlabeled. Structured sections use the label and style for their
+ * `kind`. An object section with an invalid `kind` or non-string `text` throws
+ * `TypeError`.
+ *
+ * Reading a structured section may invoke accessors or Proxy traps, and their
+ * exceptions propagate. `format` defaults to `auto`; see {@link ErrorFormat}.
  */
 export function frame(
   header: string,

--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -1,16 +1,17 @@
 import type { VercelErrorLike } from '../types';
 
 /**
- * Rendering preset for error frames. `auto` reads `NO_COLOR`, `FORCE_COLOR`,
- * and TTY state. `plain` uses indentation only, `tree` adds Unicode connectors,
- * and `ansi` adds connectors and ANSI styling without reading ambient state.
+ * Rendering preset for error frames. `auto` checks `NO_COLOR`, then
+ * `FORCE_COLOR`, then TTY state; any defined environment value counts as
+ * present. `plain` uses indentation, `tree` adds Unicode connectors, and
+ * `ansi` adds connectors and ANSI styling without reading ambient state.
  */
 export type ErrorFormat = 'auto' | 'plain' | 'tree' | 'ansi';
 
 /**
- * Content accepted by {@link frame}. Strings are unlabeled details. Structured
- * variants select library-owned labels, connectors, and styles; their text is
- * sanitized during rendering. Raw string prefixes carry no special meaning.
+ * A section accepted by {@link frame}. Strings render as unlabeled details.
+ * Structured sections add the label, connector, and style for their `kind`.
+ * Rendering sanitizes all text; prefixes in string sections are not parsed.
  * Use {@link hint}, {@link fix}, and {@link link} to create structured sections.
  */
 export type FrameSection =
@@ -20,13 +21,13 @@ export type FrameSection =
   | { readonly kind: 'link'; readonly text: string };
 
 /**
- * Render an error with deterministic or environment-detected formatting.
+ * Render developer-facing error fields as a sanitized terminal frame.
  *
- * `auto` detects tree and color support. `plain` uses indentation only, `tree`
- * uses Unicode connectors without color, and `ansi` uses connectors and ANSI
- * styling without consulting ambient terminal state. Every caller-controlled
- * physical line is sanitized and placed under a library-owned prefix. Omitting
- * `format` selects `auto`, the only preset that reads ambient terminal state.
+ * Control characters are removed, CRLF is normalized, and continuation lines
+ * are prefixed by the renderer. This output may contain developer-only details;
+ * use `errorResponse()` from `@vercel/error/server` for client-safe transport.
+ * `format` defaults to `auto`; see {@link ErrorFormat}. Accessors and Proxy traps
+ * on structural input may execute, and their exceptions propagate.
  */
 export function formatError(
   error: VercelErrorLike,
@@ -60,12 +61,14 @@ export function formatError(
 }
 
 /**
- * Compose a sanitized frame from a header and raw or structured sections.
+ * Render a header and optional sections as a sanitized terminal frame.
  *
- * Structured sections control labels, connectors, and ANSI styling without a
- * string-prefix protocol. Falsy sections are omitted. `format` has the same
- * preset meanings as {@link formatError} and defaults to `auto`. A malformed
- * structured section supplied at runtime throws `TypeError`.
+ * `null`, `undefined`, `false`, and empty string sections are omitted. String
+ * sections remain unlabeled; structured sections receive the label and style
+ * for their `kind`. Malformed objects with ordinary data properties throw
+ * `TypeError`. Accessors and Proxy traps may execute during validation, and
+ * their exceptions propagate. `format` defaults to `auto`; see
+ * {@link ErrorFormat}.
  */
 export function frame(
   header: string,

--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -1,9 +1,18 @@
 import type { VercelErrorLike } from '../types';
 
-/** Named rendering preset for error frames. */
+/**
+ * Rendering preset for error frames. `auto` reads `NO_COLOR`, `FORCE_COLOR`,
+ * and TTY state. `plain` uses indentation only, `tree` adds Unicode connectors,
+ * and `ansi` adds connectors and ANSI styling without reading ambient state.
+ */
 export type ErrorFormat = 'auto' | 'plain' | 'tree' | 'ansi';
 
-/** Structured content accepted by {@link frame}. */
+/**
+ * Content accepted by {@link frame}. Strings are unlabeled details. Structured
+ * variants select library-owned labels, connectors, and styles; their text is
+ * sanitized during rendering. Raw string prefixes carry no special meaning.
+ * Use {@link hint}, {@link fix}, and {@link link} to create structured sections.
+ */
 export type FrameSection =
   | string
   | { readonly kind: 'hint'; readonly text: string }
@@ -21,7 +30,10 @@ export type FrameSection =
  */
 export function formatError(
   error: VercelErrorLike,
-  options: { readonly format?: ErrorFormat } = {},
+  options: {
+    /** Rendering preset; omission selects `auto`. */
+    readonly format?: ErrorFormat;
+  } = {},
 ): string {
   const capabilities = resolveFormat(options.format ?? 'auto');
   const qualifier = [error.scope, error.code].filter(Boolean).join(':');
@@ -52,12 +64,16 @@ export function formatError(
  *
  * Structured sections control labels, connectors, and ANSI styling without a
  * string-prefix protocol. Falsy sections are omitted. `format` has the same
- * preset meanings as {@link formatError} and defaults to `auto`.
+ * preset meanings as {@link formatError} and defaults to `auto`. A malformed
+ * structured section supplied at runtime throws `TypeError`.
  */
 export function frame(
   header: string,
   sections?: readonly (FrameSection | null | undefined | false)[],
-  options: { readonly format?: ErrorFormat } = {},
+  options: {
+    /** Rendering preset; omission selects `auto`. */
+    readonly format?: ErrorFormat;
+  } = {},
 ): string {
   return renderFrame({
     ...resolveFormat(options.format ?? 'auto'),

--- a/src/get-message/index.spec.ts
+++ b/src/get-message/index.spec.ts
@@ -3,15 +3,15 @@ import { describe, expect, it } from 'vitest';
 import { getMessage } from '.';
 
 describe('getMessage', () => {
-  it('extracts message from Error', () => {
+  it('returns the message from an Error', () => {
     expect(getMessage(new Error('test error'))).toBe('test error');
   });
 
-  it('extracts message from error-like objects', () => {
+  it('returns the message from an object', () => {
     expect(getMessage({ message: 'custom error' })).toBe('custom error');
   });
 
-  it('returns the same message value it validated', () => {
+  it('reads a string message accessor once', () => {
     let reads = 0;
     const error = {
       get message(): unknown {
@@ -24,11 +24,11 @@ describe('getMessage', () => {
     expect(reads).toBe(1);
   });
 
-  it('returns string values as-is', () => {
+  it('returns a string unchanged', () => {
     expect(getMessage('raw string')).toBe('raw string');
   });
 
-  it('JSON stringifies plain objects', () => {
+  it('returns JSON for a plain object', () => {
     expect(getMessage({ key: 'value' })).toBe('{"key":"value"}');
   });
 
@@ -48,20 +48,20 @@ describe('getMessage', () => {
     expect(getMessage(42, 'fallback')).toBe('fallback');
   });
 
-  it('handles circular references gracefully', () => {
+  it('returns the serialization fallback for a circular object', () => {
     const obj: Record<string, unknown> = {};
     obj['self'] = obj;
-    expect(getMessage(obj)).toBe('[Object - Unable to Stringify Error Object]');
+    expect(getMessage(obj)).toBe('[Object - JSON serialization failed]');
   });
 
   it.each([
-    ['missing', undefined],
-    ['null', null],
-    ['number', 42],
-    ['symbol', Symbol('constructor')],
-    ['non-string name', { name: 42 }],
+    ['a missing constructor', undefined],
+    ['a null constructor', null],
+    ['a numeric constructor', 42],
+    ['a symbol constructor', Symbol('constructor')],
+    ['a non-string constructor name', { name: 42 }],
     [
-      'throwing name',
+      'a constructor name getter that throws',
       new Proxy(
         {},
         {
@@ -72,16 +72,14 @@ describe('getMessage', () => {
         },
       ),
     ],
-  ])('uses Object for %s constructor metadata', (_label, constructor) => {
+  ])('uses Object for %s', (_label, constructor) => {
     const error: Record<string, unknown> = { constructor };
     error['self'] = error;
 
-    expect(getMessage(error)).toBe(
-      '[Object - Unable to Stringify Error Object]',
-    );
+    expect(getMessage(error)).toBe('[Object - JSON serialization failed]');
   });
 
-  it('uses Object when constructor lookup also throws', () => {
+  it('uses Object when reading constructor throws', () => {
     const error: Record<string, unknown> = {};
     error['self'] = error;
     Object.defineProperty(error, 'constructor', {
@@ -90,12 +88,10 @@ describe('getMessage', () => {
       },
     });
 
-    expect(getMessage(error)).toBe(
-      '[Object - Unable to Stringify Error Object]',
-    );
+    expect(getMessage(error)).toBe('[Object - JSON serialization failed]');
   });
 
-  it('uses the same constructor name value it validated', () => {
+  it('reads constructor.name once for the serialization fallback', () => {
     let reads = 0;
     const error: Record<string, unknown> = {};
     error['self'] = error;
@@ -106,9 +102,7 @@ describe('getMessage', () => {
       },
     };
 
-    expect(getMessage(error)).toBe(
-      '[StableError - Unable to Stringify Error Object]',
-    );
+    expect(getMessage(error)).toBe('[StableError - JSON serialization failed]');
     expect(reads).toBe(1);
   });
 

--- a/src/get-message/index.spec.ts
+++ b/src/get-message/index.spec.ts
@@ -51,8 +51,34 @@ describe('getMessage', () => {
   it('handles circular references gracefully', () => {
     const obj: Record<string, unknown> = {};
     obj['self'] = obj;
-    const result = getMessage(obj);
-    expect(result).toContain('Unable to Stringify');
+    expect(getMessage(obj)).toBe('[Object - Unable to Stringify Error Object]');
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['null', null],
+    ['number', 42],
+    ['symbol', Symbol('constructor')],
+    ['non-string name', { name: 42 }],
+    [
+      'throwing name',
+      new Proxy(
+        {},
+        {
+          get(_target, property) {
+            if (property === 'name') throw new Error('name unavailable');
+            return undefined;
+          },
+        },
+      ),
+    ],
+  ])('uses Object for %s constructor metadata', (_label, constructor) => {
+    const error: Record<string, unknown> = { constructor };
+    error['self'] = error;
+
+    expect(getMessage(error)).toBe(
+      '[Object - Unable to Stringify Error Object]',
+    );
   });
 
   it('uses Object when constructor lookup also throws', () => {

--- a/src/get-message/index.spec.ts
+++ b/src/get-message/index.spec.ts
@@ -11,6 +11,19 @@ describe('getMessage', () => {
     expect(getMessage({ message: 'custom error' })).toBe('custom error');
   });
 
+  it('returns the same message value it validated', () => {
+    let reads = 0;
+    const error = {
+      get message(): unknown {
+        reads += 1;
+        return reads === 1 ? 'stable message' : { changed: true };
+      },
+    };
+
+    expect(getMessage(error)).toBe('stable message');
+    expect(reads).toBe(1);
+  });
+
   it('returns string values as-is', () => {
     expect(getMessage('raw string')).toBe('raw string');
   });
@@ -40,5 +53,40 @@ describe('getMessage', () => {
     obj['self'] = obj;
     const result = getMessage(obj);
     expect(result).toContain('Unable to Stringify');
+  });
+
+  it('uses Object when constructor lookup also throws', () => {
+    const error: Record<string, unknown> = {};
+    error['self'] = error;
+    Object.defineProperty(error, 'constructor', {
+      get() {
+        throw new Error('constructor unavailable');
+      },
+    });
+
+    expect(getMessage(error)).toBe(
+      '[Object - Unable to Stringify Error Object]',
+    );
+  });
+
+  it('uses the same constructor name value it validated', () => {
+    let reads = 0;
+    const error: Record<string, unknown> = {};
+    error['self'] = error;
+    error['constructor'] = {
+      get name(): unknown {
+        reads += 1;
+        return reads === 1 ? 'StableError' : { changed: true };
+      },
+    };
+
+    expect(getMessage(error)).toBe(
+      '[StableError - Unable to Stringify Error Object]',
+    );
+    expect(reads).toBe(1);
+  });
+
+  it('returns undefined when object serialization returns undefined', () => {
+    expect(getMessage({ toJSON: () => undefined })).toBeUndefined();
   });
 });

--- a/src/get-message/index.ts
+++ b/src/get-message/index.ts
@@ -1,14 +1,17 @@
 import { isObject } from '../_internal';
 
 /**
- * Get a message string or fallback from an unknown value.
+ * Get a message string from an unknown value.
  *
- * Returns, in order, an object's string `message`, a string input, or the result
- * of `JSON.stringify` for another non-array object. Object serialization may
- * return `undefined`. If serialization throws, returns
- * `[ConstructorName - Unable to Stringify Error Object]`; failed constructor
- * lookup uses `Object`. Other values return `fallback`, which defaults to
- * `undefined`. Message accessors and Proxy traps may run and throw.
+ * Returns a string input unchanged. For a non-array object, returns its string
+ * `message` when present; otherwise returns `JSON.stringify(error)`, which may
+ * be `undefined`. If serialization throws, returns
+ * `[ConstructorName - JSON serialization failed]`. A failed constructor lookup
+ * uses `Object`.
+ *
+ * Other values return `fallback`, which defaults to `undefined`. Checking or
+ * reading `message` may invoke accessors or Proxy traps; their exceptions
+ * propagate.
  */
 export function getMessage(
   error: unknown,
@@ -30,7 +33,7 @@ export function getMessage(
       return JSON.stringify(error);
     } catch {
       const constructorName = getConstructorName(error);
-      return `[${constructorName} - Unable to Stringify Error Object]`;
+      return `[${constructorName} - JSON serialization failed]`;
     }
   }
 

--- a/src/get-message/index.ts
+++ b/src/get-message/index.ts
@@ -2,10 +2,13 @@ import { isObject } from '../_internal';
 import { isErrorLike } from '../is-error-like';
 
 /**
- * Safely extract a message from any error value.
+ * Extract a string from an unknown error value.
  *
- * Handles Error instances, error-like objects, plain objects (JSON stringified),
- * strings, and unknown values with a configurable fallback.
+ * Returns an error-like object's string `message`, then a string input, then
+ * JSON for another non-array object. If object serialization throws, returns
+ * `[ConstructorName - Unable to Stringify Error Object]`. Other values return
+ * `fallback`, which defaults to `undefined`. Property access and Proxy traps
+ * can still throw outside the guarded serialization step.
  */
 export function getMessage(
   error: unknown,

--- a/src/get-message/index.ts
+++ b/src/get-message/index.ts
@@ -1,36 +1,48 @@
 import { isObject } from '../_internal';
-import { isErrorLike } from '../is-error-like';
 
 /**
- * Extract a string from an unknown error value.
+ * Get a message string or fallback from an unknown value.
  *
- * Returns an error-like object's string `message`, then a string input, then
- * JSON for another non-array object. If object serialization throws, returns
- * `[ConstructorName - Unable to Stringify Error Object]`. Other values return
- * `fallback`, which defaults to `undefined`. Property access and Proxy traps
- * can still throw outside the guarded serialization step.
+ * Returns, in order, an object's string `message`, a string input, or the result
+ * of `JSON.stringify` for another non-array object. Object serialization may
+ * return `undefined`. If serialization throws, returns
+ * `[ConstructorName - Unable to Stringify Error Object]`; failed constructor
+ * lookup uses `Object`. Other values return `fallback`, which defaults to
+ * `undefined`. Message accessors and Proxy traps may run and throw.
  */
 export function getMessage(
   error: unknown,
   fallback?: string,
 ): string | undefined {
-  if (isErrorLike(error)) {
-    return error.message;
-  }
-
   if (typeof error === 'string') {
     return error;
   }
 
   if (isObject(error)) {
+    if ('message' in error) {
+      const message = error.message;
+      if (typeof message === 'string') {
+        return message;
+      }
+    }
+
     try {
       return JSON.stringify(error);
     } catch {
-      const constructorName =
-        (error.constructor as { name?: string } | undefined)?.name ?? 'Object';
+      const constructorName = getConstructorName(error);
       return `[${constructorName} - Unable to Stringify Error Object]`;
     }
   }
 
   return fallback;
+}
+
+function getConstructorName(error: Record<PropertyKey, unknown>): string {
+  try {
+    const constructor = error.constructor as { name?: unknown } | undefined;
+    const name = constructor?.name;
+    return typeof name === 'string' ? name : 'Object';
+  } catch {
+    return 'Object';
+  }
 }

--- a/src/get-root-cause/index.ts
+++ b/src/get-root-cause/index.ts
@@ -1,12 +1,9 @@
 import { isObject } from '../_internal';
 
 /**
- * Follow `cause` fields on arbitrary non-array objects to the root value.
- *
- * A missing or `undefined` cause stops traversal. Primitive and `null` causes
- * are returned directly. On a cycle, returns the first object encountered a
- * second time instead of throwing. Property access may invoke accessors or
- * Proxy traps, and their exceptions propagate.
+ * Follow `cause` fields on non-array objects to the last value. Missing causes
+ * stop traversal; cycles return the first repeated object. Property-access
+ * exceptions propagate.
  */
 export function getRootCause(error: unknown): unknown {
   if (!isObject(error) || !('cause' in error)) {

--- a/src/get-root-cause/index.ts
+++ b/src/get-root-cause/index.ts
@@ -1,10 +1,12 @@
 import { isObject } from '../_internal';
 
 /**
- * Traverse the error cause chain to find the root cause.
+ * Follow `cause` fields on arbitrary non-array objects to the root value.
  *
- * Walks down the chain following `cause` properties until it finds a value
- * without a cause. Uses a `WeakSet` to detect cycles.
+ * A missing or `undefined` cause stops traversal. Primitive and `null` causes
+ * are returned directly. On a cycle, returns the first object encountered a
+ * second time instead of throwing. Property access may invoke accessors or
+ * Proxy traps, and their exceptions propagate.
  */
 export function getRootCause(error: unknown): unknown {
   if (!isObject(error) || !('cause' in error)) {

--- a/src/has-code/index.ts
+++ b/src/has-code/index.ts
@@ -1,10 +1,11 @@
 import { isObject } from '../_internal';
 
 /**
- * Check an object's string `code` against one exact, case-sensitive value.
- * Accepts branded errors and plain non-array objects and narrows a match to the
- * supplied literal code. This structural check does not establish trust or
- * disclosure approval; property-access exceptions propagate.
+ * Return `true` when a non-array object's string `code` exactly matches `code`,
+ * using a case-sensitive comparison. A match narrows the object to
+ * `{ code: TCode }`. This verifies the field, not who created the object or
+ * whether the code may be disclosed. Property accessors and Proxy traps may run
+ * and throw.
  */
 export function hasCode<TCode extends string>(
   error: unknown,
@@ -12,10 +13,11 @@ export function hasCode<TCode extends string>(
 ): error is { code: TCode };
 
 /**
- * Check an object's string `code` against exact, case-sensitive values.
- * A match narrows `code` to the union of list elements; an empty list never
- * matches. Plain non-array objects are accepted. This structural check does not
- * establish trust or disclosure approval; property-access exceptions propagate.
+ * Return `true` when a non-array object's string `code` exactly matches one of
+ * `codes`, using case-sensitive comparisons. A match narrows `code` to the
+ * union of the list elements; an empty list never matches. This verifies the
+ * field, not who created the object or whether the code may be disclosed.
+ * Property accessors and Proxy traps may run and throw.
  */
 export function hasCode<TCode extends string>(
   error: unknown,

--- a/src/has-code/index.ts
+++ b/src/has-code/index.ts
@@ -1,7 +1,10 @@
 import { isObject } from '../_internal';
 
 /**
- * Check if an error has a specific error code.
+ * Check an object's string `code` against one exact, case-sensitive value.
+ * Accepts branded errors and plain non-array objects and narrows a match to the
+ * supplied literal code. This structural check does not establish trust or
+ * disclosure approval; property-access exceptions propagate.
  */
 export function hasCode<TCode extends string>(
   error: unknown,
@@ -9,16 +12,16 @@ export function hasCode<TCode extends string>(
 ): error is { code: TCode };
 
 /**
- * Check if an error has any of the specified error codes.
+ * Check an object's string `code` against exact, case-sensitive values.
+ * A match narrows `code` to the union of list elements; an empty list never
+ * matches. Plain non-array objects are accepted. This structural check does not
+ * establish trust or disclosure approval; property-access exceptions propagate.
  */
 export function hasCode<TCode extends string>(
   error: unknown,
   codes: readonly TCode[],
 ): error is { code: TCode };
 
-/**
- * Check if an error has a specific error code or any of the specified error codes.
- */
 export function hasCode<TCode extends string>(
   error: unknown,
   codeOrCodes: TCode | readonly TCode[],

--- a/src/has-code/index.ts
+++ b/src/has-code/index.ts
@@ -1,10 +1,8 @@
 import { isObject } from '../_internal';
 
 /**
- * Return `true` when a non-array object's own or inherited string `code`
- * matches `code` exactly and case-sensitively. A match narrows the object to
- * `{ code: TCode }`. Reading `code` may invoke accessors or Proxy traps, and
- * their exceptions propagate.
+ * Match a non-array object's string `code` exactly and case-sensitively, then
+ * narrow to `{ code: TCode }`. Property-access exceptions propagate.
  */
 export function hasCode<TCode extends string>(
   error: unknown,
@@ -12,11 +10,9 @@ export function hasCode<TCode extends string>(
 ): error is { code: TCode };
 
 /**
- * Return `true` when a non-array object's own or inherited string `code`
- * exactly matches one of `codes`, using case-sensitive comparisons. A match
- * narrows `code` to the union of the list elements; an empty list never
- * matches. Reading `code` may invoke accessors or Proxy traps, and their
- * exceptions propagate.
+ * Match a non-array object's string `code` against a list and narrow to the
+ * matching union. Matching is exact and case-sensitive; an empty list never
+ * matches. Property-access exceptions propagate.
  */
 export function hasCode<TCode extends string>(
   error: unknown,

--- a/src/has-code/index.ts
+++ b/src/has-code/index.ts
@@ -1,11 +1,10 @@
 import { isObject } from '../_internal';
 
 /**
- * Return `true` when a non-array object's string `code` exactly matches `code`,
- * using a case-sensitive comparison. A match narrows the object to
- * `{ code: TCode }`. This verifies the field, not who created the object or
- * whether the code may be disclosed. Property accessors and Proxy traps may run
- * and throw.
+ * Return `true` when a non-array object's own or inherited string `code`
+ * matches `code` exactly and case-sensitively. A match narrows the object to
+ * `{ code: TCode }`. Reading `code` may invoke accessors or Proxy traps, and
+ * their exceptions propagate.
  */
 export function hasCode<TCode extends string>(
   error: unknown,
@@ -13,11 +12,11 @@ export function hasCode<TCode extends string>(
 ): error is { code: TCode };
 
 /**
- * Return `true` when a non-array object's string `code` exactly matches one of
- * `codes`, using case-sensitive comparisons. A match narrows `code` to the
- * union of the list elements; an empty list never matches. This verifies the
- * field, not who created the object or whether the code may be disclosed.
- * Property accessors and Proxy traps may run and throw.
+ * Return `true` when a non-array object's own or inherited string `code`
+ * exactly matches one of `codes`, using case-sensitive comparisons. A match
+ * narrows `code` to the union of the list elements; an empty list never
+ * matches. Reading `code` may invoke accessors or Proxy traps, and their
+ * exceptions propagate.
  */
 export function hasCode<TCode extends string>(
   error: unknown,

--- a/src/is-error-like/index.ts
+++ b/src/is-error-like/index.ts
@@ -2,10 +2,9 @@ import { isObject } from '../_internal';
 import type { ErrorLike } from '../types';
 
 /**
- * Return `true` for a non-array object whose own or inherited `message` is a
- * string, including an empty string. Does not check `name`, `stack`, or whether
- * the object is an `Error` instance. Property accessors and Proxy traps may run
- * and throw.
+ * Match a non-array object with a string `message`, including an empty string.
+ * Does not check `name`, `stack`, or `Error` identity. Property-access
+ * exceptions propagate.
  */
 export function isErrorLike(error: unknown): error is ErrorLike {
   return (

--- a/src/is-error-like/index.ts
+++ b/src/is-error-like/index.ts
@@ -2,7 +2,10 @@ import { isObject } from '../_internal';
 import type { ErrorLike } from '../types';
 
 /**
- * Check if a value is an error-like object (has a `message` string property).
+ * Check whether a non-array object has an own or inherited string `message`.
+ * Blank messages pass. This structural check does not establish Error branding
+ * or producer trust and does not validate `name` or `stack`. Property access
+ * may invoke accessors or Proxy traps, and their exceptions propagate.
  */
 export function isErrorLike(error: unknown): error is ErrorLike {
   return (

--- a/src/is-error-like/index.ts
+++ b/src/is-error-like/index.ts
@@ -2,10 +2,10 @@ import { isObject } from '../_internal';
 import type { ErrorLike } from '../types';
 
 /**
- * Check whether a non-array object has an own or inherited string `message`.
- * Blank messages pass. This structural check does not establish Error branding
- * or producer trust and does not validate `name` or `stack`. Property access
- * may invoke accessors or Proxy traps, and their exceptions propagate.
+ * Return `true` for a non-array object whose own or inherited `message` is a
+ * string, including an empty string. Does not check `name`, `stack`, or whether
+ * the object is an `Error` instance. Property accessors and Proxy traps may run
+ * and throw.
  */
 export function isErrorLike(error: unknown): error is ErrorLike {
   return (

--- a/src/is-vercel-error/index.ts
+++ b/src/is-vercel-error/index.ts
@@ -4,19 +4,18 @@ import { VercelError } from '../vercel-error';
 import { VERCEL_ERROR_TAG } from '../vercel-error/tag';
 
 /**
- * Check whether a value is a local VercelError instance or valid tagged
- * cross-realm VercelErrorLike data.
+ * Return `true` for a local `VercelError` instance or an object with the package
+ * symbol tag and valid `VercelErrorLike` fields.
  *
  * Two checks, in order:
  * 1. Fast path: `instanceof` check for same-realm objects
  * 2. Fallback: stable tag plus structural validation for cross-realm data
  *
- * The tag is forgeable. A successful check does not authenticate the producer,
- * authorize disclosure, or make class methods safe to invoke. Use
- * `instanceof VercelError` when local class behavior is required. Recognition
- * permits a blank `public.message` that response serialization rejects later;
- * `metadata` and `attributes` are checked only as non-array objects. Property
- * access may invoke accessors or Proxy traps, and their exceptions propagate.
+ * The tag can be forged, so tagged-object recognition validates field shape but
+ * does not verify who created the value or approve its fields for disclosure.
+ * Use `instanceof VercelError` before calling class methods. Tagged objects may
+ * have a blank `public.message`; `metadata` and `attributes` need only be
+ * non-array objects. Property accessors and Proxy traps may run and throw.
  */
 export function isVercelError(error: unknown): error is VercelErrorLike {
   if (error instanceof VercelError) {

--- a/src/is-vercel-error/index.ts
+++ b/src/is-vercel-error/index.ts
@@ -4,14 +4,18 @@ import { VercelError } from '../vercel-error';
 import { VERCEL_ERROR_TAG } from '../vercel-error/tag';
 
 /**
- * Return `true` for a local `VercelError` instance or an object with the package
- * symbol tag and valid `VercelErrorLike` fields.
+ * Return `true` for a local `VercelError` instance without revalidating its
+ * fields. For other objects, require the package symbol tag and validate the
+ * `VercelErrorLike` fields.
  *
- * The tag can be forged, so tagged-object recognition validates field shape but
- * does not verify who created the value or approve its fields for disclosure.
- * Use `instanceof VercelError` before calling class methods. Tagged objects may
- * have a blank `public.message`; `metadata` and `attributes` need only be
- * non-array objects. Property accessors and Proxy traps may run and throw.
+ * Any object can forge the tag. For a non-local tagged object, `true` means only
+ * that its fields have the expected runtime shapes; it does not establish where
+ * the object came from or make developer-facing fields safe to send to clients.
+ * Use `instanceof VercelError` before calling class methods.
+ *
+ * Tagged objects may have a blank `public.message`; `metadata` and `attributes`
+ * may be any non-array objects. Property accessors and Proxy traps may run and
+ * throw.
  */
 export function isVercelError(error: unknown): error is VercelErrorLike {
   if (error instanceof VercelError) {

--- a/src/is-vercel-error/index.ts
+++ b/src/is-vercel-error/index.ts
@@ -13,7 +13,10 @@ import { VERCEL_ERROR_TAG } from '../vercel-error/tag';
  *
  * The tag is forgeable. A successful check does not authenticate the producer,
  * authorize disclosure, or make class methods safe to invoke. Use
- * `instanceof VercelError` when local class behavior is required.
+ * `instanceof VercelError` when local class behavior is required. Recognition
+ * permits a blank `public.message` that response serialization rejects later;
+ * `metadata` and `attributes` are checked only as non-array objects. Property
+ * access may invoke accessors or Proxy traps, and their exceptions propagate.
  */
 export function isVercelError(error: unknown): error is VercelErrorLike {
   if (error instanceof VercelError) {

--- a/src/is-vercel-error/index.ts
+++ b/src/is-vercel-error/index.ts
@@ -4,18 +4,10 @@ import { VercelError } from '../vercel-error';
 import { VERCEL_ERROR_TAG } from '../vercel-error/tag';
 
 /**
- * Return `true` for a local `VercelError` instance without revalidating its
- * fields. For other objects, require the package symbol tag and validate the
- * `VercelErrorLike` fields.
- *
- * Any object can forge the tag. For a non-local tagged object, `true` means only
- * that its fields have the expected runtime shapes; it does not establish where
- * the object came from or make developer-facing fields safe to send to clients.
- * Use `instanceof VercelError` before calling class methods.
- *
- * Tagged objects may have a blank `public.message`; `metadata` and `attributes`
- * may be any non-array objects. Property accessors and Proxy traps may run and
- * throw.
+ * Match a local `VercelError` or tagged data with valid `VercelErrorLike`
+ * fields. Any object can forge the tag, so use `instanceof VercelError` before
+ * calling methods. Tagged `public.message` may be blank; serialization checks
+ * it later. Property-access exceptions propagate.
  */
 export function isVercelError(error: unknown): error is VercelErrorLike {
   if (error instanceof VercelError) {

--- a/src/is-vercel-error/index.ts
+++ b/src/is-vercel-error/index.ts
@@ -7,10 +7,6 @@ import { VERCEL_ERROR_TAG } from '../vercel-error/tag';
  * Return `true` for a local `VercelError` instance or an object with the package
  * symbol tag and valid `VercelErrorLike` fields.
  *
- * Two checks, in order:
- * 1. Fast path: `instanceof` check for same-realm objects
- * 2. Fallback: stable tag plus structural validation for cross-realm data
- *
  * The tag can be forged, so tagged-object recognition validates field shape but
  * does not verify who created the value or approve its fields for disclosure.
  * Use `instanceof VercelError` before calling class methods. Tagged objects may

--- a/src/to-error-response/index.ts
+++ b/src/to-error-response/index.ts
@@ -8,40 +8,26 @@ import type { PublicErrorDetails, VercelErrorLike } from '../types';
 import { wantsAnsi, type HeadersLike } from '../wants-ansi';
 
 /**
- * Client-facing input for callers that do not have a `VercelError`. The
- * response includes `scope`, `code`, every text field, and the HTTP status.
- * `statusCode` defaults to 500 and must be an integer from 400 through 599;
- * {@link errorResponse} throws `RangeError` otherwise. Optional fields set to
- * `undefined` are omitted.
+ * Client-facing input used without a `VercelError`. All defined fields are
+ * included in the response. `statusCode` defaults to 500 and accepts 400-599.
  */
 export interface ErrorResponseInput extends PublicErrorDetails {
   /** Optional error scope included in the response. */
   readonly scope?: string;
   /** Optional stable error code included in the response. */
   readonly code?: string;
-  /**
-   * Authored HTTP status mapping. Omission defaults to 500; only integers from
-   * 400 through 599 are accepted.
-   */
+  /** Status mapping; defaults to 500 or throws `RangeError` unless 400-599. */
   readonly statusCode?: number;
 }
 
-/** Options for selecting the body format and observing serialization. */
+/** Options for body format and the `onSerialize` callback. */
 export interface ErrorResponseOptions {
-  /**
-   * Request or headers used to select the body format. Omission uses JSON. A
-   * present `X-Error-Format` is checked first, followed by `Accept`, then the
-   * `User-Agent` curl check; see {@link wantsAnsi}.
-   */
+  /** Request or headers used for body selection; omission uses JSON. */
   readonly request?: Request | HeadersLike;
 
   /**
-   * Called synchronously after the complete `ErrorResponse` is built.
-   *
-   * The callback receives the original source, not response data, so it may
-   * include developer-facing fields and debugging context. If the callback
-   * throws, `errorResponse()` throws instead of returning the response. The
-   * callback must return `undefined`, so TypeScript rejects async callbacks.
+   * Called with the original source after the response is built. Exceptions
+   * propagate. Must return `undefined`; TypeScript rejects async callbacks.
    */
   readonly onSerialize?: (
     source: VercelErrorLike | ErrorResponseInput,
@@ -55,22 +41,15 @@ export interface ErrorResponseOptions {
 }
 
 /**
- * Complete HTTP response data returned by {@link errorResponse}. The body is
- * already serialized. Pass `body`, `status`, and `headers` to a native or
- * framework response constructor.
+ * HTTP response data returned by {@link errorResponse}. Pass these fields to a
+ * native or framework response constructor.
  */
 export interface ErrorResponse {
   /** Concrete HTTP status to send. */
   readonly status: number;
-  /**
-   * JSON-serialized `ErrorResponseData` or ANSI-formatted text containing the
-   * same error identity and public details.
-   */
+  /** Serialized `ErrorResponseData` or ANSI text with the same public fields. */
   readonly body: string;
-  /**
-   * Response headers containing the `Content-Type` that matches `body`:
-   * `application/json` or `text/plain; charset=utf-8`.
-   */
+  /** Matching JSON or plain-text `Content-Type` header. */
   readonly headers: Record<string, string>;
 }
 
@@ -80,22 +59,15 @@ const TEXT_HEADERS = { 'Content-Type': 'text/plain; charset=utf-8' } as const;
 /**
  * Build HTTP response data from an error or explicit public data.
  *
- * For local `VercelError` instances and tagged `VercelErrorLike` values,
- * response text comes only from `public`. If `public` is absent, the response
- * uses a fixed generic message. Untagged values recognized as errors, and
- * untagged objects with a `name` or `stack` field, throw `TypeError`. Other
- * untagged objects are treated as `ErrorResponseInput`, whose identity and text
- * are all client-visible.
+ * `VercelError` and tagged values expose only `public`, `scope`, and `code`; a
+ * missing `public` uses a generic message. Untagged errors and objects with
+ * `name` or `stack` throw `TypeError`. Other objects are treated as fully public
+ * `ErrorResponseInput`.
  *
- * The response also includes `scope`, `code`, and the concrete HTTP status.
- * Header negotiation changes only the body format; callers must decide which
- * requester may receive those fields before calling this function.
- *
- * `statusCode` defaults to 500. Values that are not integers from 400 through
- * 599 throw `RangeError` before response data is built. Invalid tagged data or
- * public fields throw `TypeError`. Source accessors and Proxy traps may run and
- * throw. `onSerialize` runs only after the complete response is built, and its
- * exceptions propagate.
+ * `statusCode` defaults to 500 and accepts integers from 400 through 599.
+ * Invalid status throws `RangeError`; invalid public data throws `TypeError`.
+ * Property-access exceptions propagate. `onSerialize` runs after the response
+ * is built.
  *
  * @example
  * ```ts

--- a/src/to-error-response/index.ts
+++ b/src/to-error-response/index.ts
@@ -37,13 +37,11 @@ export interface ErrorResponseOptions {
   readonly request?: Request | HeadersLike;
 
   /**
-   * Synchronous diagnostics callback invoked after the complete
-   * `ErrorResponse` result is built.
+   * Called synchronously after the complete `ErrorResponse` is built.
    *
-   * The callback receives the original source so server-side instrumentation
-   * can inspect its context. The source retains its existing trust level.
-   * Exceptions propagate and replace the response the caller would otherwise
-   * receive. Async callbacks are rejected by the `undefined` return type.
+   * The callback receives the original source for server-side diagnostics.
+   * Exceptions propagate instead of returning the response. The callback must
+   * return `undefined`, so TypeScript rejects async callbacks.
    */
   readonly onSerialize?: (
     source: VercelErrorLike | ErrorResponseInput,
@@ -91,7 +89,8 @@ const TEXT_HEADERS = { 'Content-Type': 'text/plain; charset=utf-8' } as const;
  * Status validation runs before projection and throws `RangeError` for invalid
  * values. Invalid tagged data or public fields throw `TypeError` during
  * projection. `onSerialize` runs synchronously only after the complete result
- * is built; its exceptions propagate.
+ * is built; its exceptions propagate. Source accessors and Proxy traps may run,
+ * and their exceptions propagate without invoking `onSerialize`.
  *
  * @example
  * ```ts

--- a/src/to-error-response/index.ts
+++ b/src/to-error-response/index.ts
@@ -16,12 +16,12 @@ import { wantsAnsi, type HeadersLike } from '../wants-ansi';
  * data.
  */
 export interface ErrorResponseInput extends PublicErrorDetails {
-  /** Optional public identity namespace. */
+  /** Optional error scope included in the response. */
   readonly scope?: string;
-  /** Optional public stable error code. */
+  /** Optional stable error code included in the response. */
   readonly code?: string;
   /**
-   * Public HTTP status mapping. Omission defaults to 500; only integers from
+   * Authored HTTP status mapping. Omission defaults to 500; only integers from
    * 400 through 599 are accepted.
    */
   readonly statusCode?: number;
@@ -40,8 +40,9 @@ export interface ErrorResponseOptions {
    * Called synchronously after the complete `ErrorResponse` is built.
    *
    * The callback receives the original source for server-side diagnostics.
-   * Exceptions propagate instead of returning the response. The callback must
-   * return `undefined`, so TypeScript rejects async callbacks.
+   * The source retains its existing trust level. Exceptions propagate instead
+   * of returning the response. The callback must return `undefined`, so
+   * TypeScript rejects async callbacks.
    */
   readonly onSerialize?: (
     source: VercelErrorLike | ErrorResponseInput,
@@ -62,7 +63,7 @@ export interface ErrorResponseOptions {
 export interface ErrorResponse {
   /** Concrete HTTP status to send. */
   readonly status: number;
-  /** JSON Vercel-envelope data or negotiated ANSI-formatted public text. */
+  /** Serialized Vercel JSON envelope or ANSI-formatted public error text. */
   readonly body: string;
   /**
    * Headers for the response constructor: `application/json` or
@@ -83,14 +84,16 @@ const TEXT_HEADERS = { 'Content-Type': 'text/plain; charset=utf-8' } as const;
  * (carrying `name` or `stack`) throw `TypeError`; other untagged objects are
  * treated as `ErrorResponseInput`.
  * Scope, code, status, and every flat prose field are client-visible. Request
- * headers select the body format; they do not authorize access.
+ * headers select the body format; they do not decide whether the requester may
+ * receive those fields.
  *
  * `statusCode` defaults to 500 and must be an integer from 400 through 599.
- * Status validation runs before projection and throws `RangeError` for invalid
- * values. Invalid tagged data or public fields throw `TypeError` during
- * projection. `onSerialize` runs synchronously only after the complete result
- * is built; its exceptions propagate. Source accessors and Proxy traps may run,
- * and their exceptions propagate without invoking `onSerialize`.
+ * Status is validated before response data is built; invalid values throw
+ * `RangeError`. Invalid tagged data or public fields throw `TypeError` while
+ * response data is built. `onSerialize` runs synchronously only after the
+ * complete result is built; its exceptions propagate. Source accessors and
+ * Proxy traps may run, and their exceptions propagate without invoking
+ * `onSerialize`.
  *
  * @example
  * ```ts

--- a/src/to-error-response/index.ts
+++ b/src/to-error-response/index.ts
@@ -8,12 +8,11 @@ import type { PublicErrorDetails, VercelErrorLike } from '../types';
 import { wantsAnsi, type HeadersLike } from '../wants-ansi';
 
 /**
- * Flat, explicitly public input for callers that do not have a VercelError.
- * `scope`, `code`, every prose field, and the resulting concrete status are
- * client-visible disclosures. `statusCode` defaults to 500 and must be an
- * integer from 400 through 599; {@link errorResponse} throws `RangeError`
- * otherwise. Explicitly `undefined` optional fields are omitted from response
- * data.
+ * Client-facing input for callers that do not have a `VercelError`. The
+ * response includes `scope`, `code`, every text field, and the HTTP status.
+ * `statusCode` defaults to 500 and must be an integer from 400 through 599;
+ * {@link errorResponse} throws `RangeError` otherwise. Optional fields set to
+ * `undefined` are omitted.
  */
 export interface ErrorResponseInput extends PublicErrorDetails {
   /** Optional error scope included in the response. */
@@ -27,22 +26,22 @@ export interface ErrorResponseInput extends PublicErrorDetails {
   readonly statusCode?: number;
 }
 
-/** Options for HTTP negotiation and serialization diagnostics. */
+/** Options for selecting the body format and observing serialization. */
 export interface ErrorResponseOptions {
   /**
    * Request or headers used to select the body format. Omission uses JSON. A
-   * present `X-Error-Format` is authoritative, followed by `Accept`, then the
-   * `User-Agent` curl heuristic; see {@link wantsAnsi}.
+   * present `X-Error-Format` is checked first, followed by `Accept`, then the
+   * `User-Agent` curl check; see {@link wantsAnsi}.
    */
   readonly request?: Request | HeadersLike;
 
   /**
    * Called synchronously after the complete `ErrorResponse` is built.
    *
-   * The callback receives the original source for server-side diagnostics.
-   * The source retains its existing trust level. Exceptions propagate instead
-   * of returning the response. The callback must return `undefined`, so
-   * TypeScript rejects async callbacks.
+   * The callback receives the original source, not response data, so it may
+   * include developer-facing fields and debugging context. If the callback
+   * throws, `errorResponse()` throws instead of returning the response. The
+   * callback must return `undefined`, so TypeScript rejects async callbacks.
    */
   readonly onSerialize?: (
     source: VercelErrorLike | ErrorResponseInput,
@@ -56,18 +55,21 @@ export interface ErrorResponseOptions {
 }
 
 /**
- * Complete framework-neutral HTTP response returned by {@link errorResponse}.
- * The body is already serialized. Use `body`, `status`, and `headers` to
- * construct a native or framework response.
+ * Complete HTTP response data returned by {@link errorResponse}. The body is
+ * already serialized. Pass `body`, `status`, and `headers` to a native or
+ * framework response constructor.
  */
 export interface ErrorResponse {
   /** Concrete HTTP status to send. */
   readonly status: number;
-  /** Serialized Vercel JSON envelope or ANSI-formatted public error text. */
+  /**
+   * JSON-serialized `ErrorResponseData` or ANSI-formatted text containing the
+   * same error identity and public details.
+   */
   readonly body: string;
   /**
-   * Headers for the response constructor: `application/json` or
-   * `text/plain; charset=utf-8`, matching `body`.
+   * Response headers containing the `Content-Type` that matches `body`:
+   * `application/json` or `text/plain; charset=utf-8`.
    */
   readonly headers: Record<string, string>;
 }
@@ -76,24 +78,24 @@ const JSON_HEADERS = { 'Content-Type': 'application/json' } as const;
 const TEXT_HEADERS = { 'Content-Type': 'text/plain; charset=utf-8' } as const;
 
 /**
- * Build a framework-neutral HTTP response from an error or explicit public data.
+ * Build HTTP response data from an error or explicit public data.
  *
- * Local `VercelError` instances and tagged `VercelErrorLike` values expose only
- * their approved `public` details, or the fixed generic fallback when those
- * details are absent. Untagged native, cross-realm, and Error-shaped objects
- * (carrying `name` or `stack`) throw `TypeError`; other untagged objects are
- * treated as `ErrorResponseInput`.
- * Scope, code, status, and every flat prose field are client-visible. Request
- * headers select the body format; they do not decide whether the requester may
- * receive those fields.
+ * For local `VercelError` instances and tagged `VercelErrorLike` values,
+ * response text comes only from `public`. If `public` is absent, the response
+ * uses a fixed generic message. Untagged values recognized as errors, and
+ * untagged objects with a `name` or `stack` field, throw `TypeError`. Other
+ * untagged objects are treated as `ErrorResponseInput`, whose identity and text
+ * are all client-visible.
  *
- * `statusCode` defaults to 500 and must be an integer from 400 through 599.
- * Status is validated before response data is built; invalid values throw
- * `RangeError`. Invalid tagged data or public fields throw `TypeError` while
- * response data is built. `onSerialize` runs synchronously only after the
- * complete result is built; its exceptions propagate. Source accessors and
- * Proxy traps may run, and their exceptions propagate without invoking
- * `onSerialize`.
+ * The response also includes `scope`, `code`, and the concrete HTTP status.
+ * Header negotiation changes only the body format; callers must decide which
+ * requester may receive those fields before calling this function.
+ *
+ * `statusCode` defaults to 500. Values that are not integers from 400 through
+ * 599 throw `RangeError` before response data is built. Invalid tagged data or
+ * public fields throw `TypeError`. Source accessors and Proxy traps may run and
+ * throw. `onSerialize` runs only after the complete response is built, and its
+ * exceptions propagate.
  *
  * @example
  * ```ts

--- a/src/to-error-response/index.ts
+++ b/src/to-error-response/index.ts
@@ -16,8 +16,14 @@ import { wantsAnsi, type HeadersLike } from '../wants-ansi';
  * data.
  */
 export interface ErrorResponseInput extends PublicErrorDetails {
+  /** Optional public identity namespace. */
   readonly scope?: string;
+  /** Optional public stable error code. */
   readonly code?: string;
+  /**
+   * Public HTTP status mapping. Omission defaults to 500; only integers from
+   * 400 through 599 are accepted.
+   */
   readonly statusCode?: number;
 }
 
@@ -58,9 +64,12 @@ export interface ErrorResponseOptions {
 export interface ErrorResponse {
   /** Concrete HTTP status to send. */
   readonly status: number;
-  /** Serialized JSON or structured ANSI text body. */
+  /** JSON Vercel-envelope data or negotiated ANSI-formatted public text. */
   readonly body: string;
-  /** Headers to pass to the response constructor. */
+  /**
+   * Headers for the response constructor: `application/json` or
+   * `text/plain; charset=utf-8`, matching `body`.
+   */
   readonly headers: Record<string, string>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
 /**
- * Recursive type for structured metadata values, allowing arbitrarily nested
- * domain context.
+ * Values allowed in nested error metadata.
  */
 export type SerializableValue =
   | string
@@ -12,23 +11,21 @@ export type SerializableValue =
   | { [key: string]: SerializableValue };
 
 /**
- * Domain-specific structured context for debugging and logging.
- * Can contain arbitrarily nested values. Server-side only, so it is excluded
- * from HTTP error responses.
+ * Nested application data for debugging and logging. It stays server-side and
+ * is excluded from HTTP error responses.
  *
- * Use in internal diagnostic serialization, logging, and debugging tools.
+ * Use in `toJSON()`, logs, and debugging tools.
  *
  * @example { userId: '123', query: { table: 'users', limit: 50 } }
  */
 export type ErrorMetadata = Record<string, SerializableValue>;
 
 /**
- * Flat key-value pairs for observability and telemetry.
- * Compatible with OpenTelemetry's AttributeValue type.
- * When attached to `VercelError`, attributes appear in diagnostic `toJSON()`
- * output but never in `ErrorResponseData` or HTTP response bodies.
+ * Flat values compatible with OpenTelemetry's `AttributeValue` type, suitable
+ * for spans, error-tracker tags, and metrics.
  *
- * Route to: tracing spans, Sentry tags, metrics dashboards.
+ * When attached to `VercelError`, attributes appear in `toJSON()` output but
+ * not in `ErrorResponseData` or HTTP response bodies.
  *
  * @example { 'http.method': 'POST', 'db.system': 'postgresql', 'retry.count': 3 }
  */
@@ -48,41 +45,44 @@ export interface ErrorLike {
 }
 
 /**
- * Error details explicitly approved for disclosure to clients.
+ * Error details explicitly approved for a specific client audience.
  *
- * `message` is required and must be nonblank; optional fields must be
- * strings. The `VercelError` constructor validates these rules, and
- * `errorResponse()` re-validates flat and tagged cross-realm input at
- * serialization; invalid details throw `TypeError`. This prevents transport
- * serialization from falling back to developer-facing prose. Applications
- * remain responsible for ensuring every supplied field is safe for the
- * intended audience.
+ * `message` must contain non-whitespace text; optional fields must be strings.
+ * The `VercelError` constructor validates these rules, drops unknown fields,
+ * and stores a frozen copy. `errorResponse()` applies the same field validation
+ * to flat input and `VercelErrorLike` data. Invalid known fields throw
+ * `TypeError`.
+ *
+ * Receiving recovery guidance does not by itself authorize following a fix or
+ * link.
  */
 export interface PublicErrorDetails {
-  /** Client-facing description containing non-whitespace text. */
+  /** Client-facing summary containing non-whitespace text. */
   readonly message: string;
-  /** Optional client-facing explanation of why the error occurred. */
+  /** Client-facing explanation of why the error occurred. */
   readonly reason?: string;
-  /** Optional client-facing investigation advice. */
+  /** Client-facing investigation advice. */
   readonly hint?: string;
-  /** Optional client-facing recovery guidance; it does not authorize action. */
+  /** Client-facing recovery guidance. */
   readonly fix?: string;
-  /** Optional client-facing URL; verify its producer before following it. */
+  /** Client-facing documentation URL. */
   readonly link?: string;
 }
 
 /**
- * Configuration options for creating a VercelError instance.
+ * Options for constructing a `VercelError`.
  *
- * `reason`, `hint`, `fix`, and `link` are developer-facing. Client prose must
- * be supplied separately under `public`. `scope`, `code`, and the resulting
- * HTTP status are also client-visible when an error becomes a response.
- * `cause`, `requestId`, `metadata`, and `attributes` remain diagnostic only.
+ * `reason`, `hint`, `fix`, and `link` are developer-facing. Client-facing text
+ * must be supplied separately under `public`. `errorResponse()` also includes
+ * `scope` and `code`, and maps `statusCode` to the concrete HTTP status.
+ *
+ * `cause`, `requestId`, `metadata`, and `attributes` are excluded from
+ * `ErrorResponseData` and HTTP response bodies.
  */
 export interface VercelErrorOptions<TCode extends string = string> {
   /**
-   * Flat OTel-compatible telemetry values. Stored by reference and never sent
-   * in error responses.
+   * Flat OpenTelemetry-compatible values. Stored by reference and excluded
+   * from error responses.
    */
   attributes?: ErrorAttributes;
 
@@ -98,10 +98,10 @@ export interface VercelErrorOptions<TCode extends string = string> {
    */
   readonly code?: TCode;
 
-  /** Known developer remediation and any required precondition. It suggests an action but does not authorize it. */
+  /** Suggested recovery step and any condition required before trying it. */
   readonly fix?: string;
 
-  /** Advisory tip that helps the developer, shown before `fix`. */
+  /** Optional developer suggestion, shown before `fix`. */
   readonly hint?: string;
 
   /** URL to documentation for this error. A `createErrors` factory with `docsBaseUrl` derives it from `code`. */
@@ -116,20 +116,20 @@ export interface VercelErrorOptions<TCode extends string = string> {
   /** Why the error happened, the root-cause explanation behind the message. */
   readonly reason?: string;
 
-  /** Diagnostic correlation ID for tracing. Never sent in error responses. */
+  /** Request ID used for tracing and excluded from error responses. */
   requestId?: string;
 
   /** Namespace that produced the error, such as a service or subsystem. */
   readonly scope?: string;
 
   /**
-   * Authored HTTP status mapping. `errorResponse()` accepts integers from 400
+   * HTTP status mapping. `errorResponse()` accepts integers from 400
    * through 599, defaults omission to 500, and throws `RangeError` otherwise.
    */
   readonly statusCode?: number;
 
   /**
-   * Details explicitly approved for client disclosure. Construction validates
+   * Details explicitly approved for a client response. Construction validates
    * the fields (nonblank string `message`, optional string details), throws
    * `TypeError` for invalid values, drops unknown fields, and stores a frozen
    * copy so later mutation of the input object cannot change them.
@@ -145,16 +145,18 @@ export interface VercelErrorOptions<TCode extends string = string> {
 }
 
 /**
- * Data contract recognized by {@link isVercelError} across realms.
+ * Data fields recognized by {@link isVercelError} across JavaScript realms.
  *
- * The stable symbol tag used for recognition is forgeable. This interface is
- * suitable for reading data fields, not for authenticating the producer,
- * authorizing disclosure, or invoking local class methods.
+ * Any object can forge the package symbol tag. For tagged non-local objects, a
+ * successful check means only that these fields have the expected runtime
+ * shapes. It does not establish where the object came from or make
+ * developer-facing fields safe to send to clients. Use
+ * `instanceof VercelError` before calling class methods.
  */
 export interface VercelErrorLike<
   TCode extends string = string,
 > extends ErrorLike {
-  /** Underlying diagnostic value; not sent in error responses. */
+  /** Original value that caused the error; excluded from error responses. */
   readonly cause?: unknown;
   /** Stable machine-readable code included by `errorResponse()` when defined. */
   readonly code?: TCode;
@@ -175,10 +177,10 @@ export interface VercelErrorLike<
   readonly link?: string;
   /** Details explicitly approved for client responses. */
   readonly public?: PublicErrorDetails;
-  /** Mutable diagnostic correlation value, excluded from responses. */
+  /** Mutable request ID, excluded from responses. */
   requestId?: string;
-  /** Mutable nested diagnostic context, excluded from responses. */
+  /** Mutable nested debugging data, excluded from responses. */
   metadata?: ErrorMetadata;
-  /** Mutable flat telemetry context, excluded from responses. */
+  /** Mutable flat OpenTelemetry-compatible values, excluded from responses. */
   attributes?: ErrorAttributes;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,8 @@ export type ErrorMetadata = Record<string, SerializableValue>;
 /**
  * Flat key-value pairs for observability and telemetry.
  * Compatible with OpenTelemetry's AttributeValue type.
+ * When attached to `VercelError`, attributes appear in diagnostic `toJSON()`
+ * output but never in `ErrorResponseData` or HTTP response bodies.
  *
  * Route to: tracing spans, Sentry tags, metrics dashboards.
  *
@@ -39,8 +41,11 @@ export type ErrorAttributes = Record<
  * Minimal interface for error-like objects with a message property.
  */
 export interface ErrorLike {
+  /** Required string inspected by {@link isErrorLike}; blank strings pass. */
   message: string;
+  /** Optional descriptive error name; {@link isErrorLike} does not inspect it. */
   name?: string;
+  /** Optional diagnostic stack; {@link isErrorLike} does not inspect it. */
   stack?: string;
 }
 
@@ -56,18 +61,31 @@ export interface ErrorLike {
  * intended audience.
  */
 export interface PublicErrorDetails {
+  /** Required nonblank description explicitly approved for clients. */
   readonly message: string;
+  /** Optional client-approved explanation of why the error occurred. */
   readonly reason?: string;
+  /** Optional client-approved advisory guidance. */
   readonly hint?: string;
+  /** Optional client-approved remediation suggestion, not authorization. */
   readonly fix?: string;
+  /** Optional client-approved URL; it does not establish trust or authority. */
   readonly link?: string;
 }
 
 /**
  * Configuration options for creating a VercelError instance.
+ *
+ * `reason`, `hint`, `fix`, and `link` are developer-facing. Client prose must
+ * be supplied separately under `public`. `scope`, `code`, and the resulting
+ * HTTP status are also client-visible when an error becomes a response.
+ * `cause`, `requestId`, `metadata`, and `attributes` remain diagnostic only.
  */
 export interface VercelErrorOptions<TCode extends string = string> {
-  /** Flat OTel-compatible tags for traces, metrics, and error trackers. */
+  /**
+   * Flat OTel-compatible telemetry values. Stored by reference and never sent
+   * in error responses.
+   */
   attributes?: ErrorAttributes;
 
   /** The underlying error or value that triggered this one, for chaining. */
@@ -91,13 +109,16 @@ export interface VercelErrorOptions<TCode extends string = string> {
   /** URL to documentation for this error. A `createErrors` factory with `docsBaseUrl` derives it from `code`. */
   readonly link?: string;
 
-  /** Nested domain context for debugging and logging. Never sent to clients. */
+  /**
+   * Nested domain context for debugging and logging. Stored by reference and
+   * never sent to clients.
+   */
   metadata?: ErrorMetadata;
 
   /** Why the error happened, the root-cause explanation behind the message. */
   readonly reason?: string;
 
-  /** Correlation ID for tracing this error across services. */
+  /** Diagnostic correlation ID for tracing. Never sent in error responses. */
   requestId?: string;
 
   /** Namespace that produced the error, such as a service or subsystem. */
@@ -135,16 +156,28 @@ export interface VercelErrorOptions<TCode extends string = string> {
 export interface VercelErrorLike<
   TCode extends string = string,
 > extends ErrorLike {
+  /** Underlying diagnostic value; not sent in error responses. */
   readonly cause?: unknown;
+  /** Stable identity code sent to clients when defined. */
   readonly code?: TCode;
+  /** Optional identity namespace sent to clients when defined. */
   readonly scope?: string;
+  /** Authored HTTP mapping, not a completed response status. */
   readonly statusCode?: number;
+  /** Developer-facing explanation unless repeated under `public`. */
   readonly reason?: string;
+  /** Developer-facing advice unless repeated under `public`. */
   readonly hint?: string;
+  /** Developer-facing remediation unless repeated under `public`. */
   readonly fix?: string;
+  /** Developer-facing URL unless repeated under `public`. */
   readonly link?: string;
+  /** Details explicitly approved for client responses. */
   readonly public?: PublicErrorDetails;
+  /** Mutable diagnostic correlation value, excluded from responses. */
   requestId?: string;
+  /** Mutable nested diagnostic context, excluded from responses. */
   metadata?: ErrorMetadata;
+  /** Mutable flat telemetry context, excluded from responses. */
   attributes?: ErrorAttributes;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,24 +10,12 @@ export type SerializableValue =
   | SerializableValue[]
   | { [key: string]: SerializableValue };
 
-/**
- * Nested application data for debugging and logging. It stays server-side and
- * is excluded from HTTP error responses.
- *
- * Use in `toJSON()`, logs, and debugging tools.
- *
- * @example { userId: '123', query: { table: 'users', limit: 50 } }
- */
+/** Nested debugging data included in `toJSON()` but excluded from responses. */
 export type ErrorMetadata = Record<string, SerializableValue>;
 
 /**
- * Flat values compatible with OpenTelemetry's `AttributeValue` type, suitable
- * for spans, error-tracker tags, and metrics.
- *
- * When attached to `VercelError`, attributes appear in `toJSON()` output but
- * not in `ErrorResponseData` or HTTP response bodies.
- *
- * @example { 'http.method': 'POST', 'db.system': 'postgresql', 'retry.count': 3 }
+ * Flat OpenTelemetry-compatible values included in `toJSON()` but excluded
+ * from responses.
  */
 export type ErrorAttributes = Record<
   string,
@@ -45,16 +33,9 @@ export interface ErrorLike {
 }
 
 /**
- * Error details explicitly approved for a specific client audience.
- *
- * `message` must contain non-whitespace text; optional fields must be strings.
- * The `VercelError` constructor validates these rules, drops unknown fields,
- * and stores a frozen copy. `errorResponse()` applies the same field validation
- * to flat input and `VercelErrorLike` data. Invalid known fields throw
- * `TypeError`.
- *
- * Receiving recovery guidance does not by itself authorize following a fix or
- * link.
+ * Text approved for clients. `message` must contain non-whitespace text;
+ * optional fields must be strings. Invalid fields throw `TypeError`. Receiving
+ * a `fix` or `link` does not authorize using it.
  */
 export interface PublicErrorDetails {
   /** Client-facing summary containing non-whitespace text. */
@@ -70,32 +51,17 @@ export interface PublicErrorDetails {
 }
 
 /**
- * Options for constructing a `VercelError`.
- *
- * `reason`, `hint`, `fix`, and `link` are developer-facing. Client-facing text
- * must be supplied separately under `public`. `errorResponse()` also includes
- * `scope` and `code`, and maps `statusCode` to the concrete HTTP status.
- *
- * `cause`, `requestId`, `metadata`, and `attributes` are excluded from
- * `ErrorResponseData` and HTTP response bodies.
+ * Options for `VercelError`. Responses include `public`, `scope`, `code`, and
+ * the mapped `statusCode`; other fields stay server-side.
  */
 export interface VercelErrorOptions<TCode extends string = string> {
-  /**
-   * Flat OpenTelemetry-compatible values. Stored by reference and excluded
-   * from error responses.
-   */
+  /** Flat OpenTelemetry-compatible values stored by reference. */
   attributes?: ErrorAttributes;
 
   /** The underlying error or value that triggered this one, for chaining. */
   readonly cause?: unknown;
 
-  /**
-   * Stable, machine-readable identifier for this error. Keep it constant even
-   * when you reword the message, so users can search it and docs can link to
-   * it. Pick whatever style fits your registry: semantic names
-   * (`pool_exhausted`), numeric codes (`E1001`), or namespaced numbers
-   * (`B2011`). Numbering is optional, so use words when you prefer them.
-   */
+  /** Stable machine-readable code; keep it unchanged when rewording messages. */
   readonly code?: TCode;
 
   /** Suggested recovery step and any condition required before trying it. */
@@ -107,10 +73,7 @@ export interface VercelErrorOptions<TCode extends string = string> {
   /** URL to documentation for this error. A `createErrors` factory with `docsBaseUrl` derives it from `code`. */
   readonly link?: string;
 
-  /**
-   * Nested domain context for debugging and logging. Stored by reference and
-   * never sent to clients.
-   */
+  /** Nested debugging data stored by reference. */
   metadata?: ErrorMetadata;
 
   /** Why the error happened, the root-cause explanation behind the message. */
@@ -122,18 +85,10 @@ export interface VercelErrorOptions<TCode extends string = string> {
   /** Namespace that produced the error, such as a service or subsystem. */
   readonly scope?: string;
 
-  /**
-   * HTTP status mapping. `errorResponse()` accepts integers from 400
-   * through 599, defaults omission to 500, and throws `RangeError` otherwise.
-   */
+  /** Status mapping; `errorResponse()` defaults to 500 or accepts 400-599. */
   readonly statusCode?: number;
 
-  /**
-   * Details explicitly approved for a client response. Construction validates
-   * the fields (nonblank string `message`, optional string details), throws
-   * `TypeError` for invalid values, drops unknown fields, and stores a frozen
-   * copy so later mutation of the input object cannot change them.
-   */
+  /** Client text; validated, copied without unknown fields, and frozen. */
   readonly public?: PublicErrorDetails;
 
   /** Reserved. Automatically captured from Error. */
@@ -145,13 +100,8 @@ export interface VercelErrorOptions<TCode extends string = string> {
 }
 
 /**
- * Data fields recognized by {@link isVercelError} across JavaScript realms.
- *
- * Any object can forge the package symbol tag. For tagged non-local objects, a
- * successful check means only that these fields have the expected runtime
- * shapes. It does not establish where the object came from or make
- * developer-facing fields safe to send to clients. Use
- * `instanceof VercelError` before calling class methods.
+ * Fields read from tagged errors in another JavaScript realm. Any object can
+ * forge the tag; use `instanceof VercelError` before calling class methods.
  */
 export interface VercelErrorLike<
   TCode extends string = string,
@@ -162,10 +112,7 @@ export interface VercelErrorLike<
   readonly code?: TCode;
   /** Error scope included by `errorResponse()` when defined. */
   readonly scope?: string;
-  /**
-   * Authored status mapping used by `errorResponse()`. Omission defaults to
-   * 500; invalid values cause `errorResponse()` to throw `RangeError`.
-   */
+  /** Status mapping; `errorResponse()` defaults to 500 or throws `RangeError`. */
   readonly statusCode?: number;
   /** Developer-facing explanation; responses use only `public.reason`. */
   readonly reason?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,9 +65,9 @@ export interface PublicErrorDetails {
   readonly reason?: string;
   /** Optional client-facing investigation advice. */
   readonly hint?: string;
-  /** Optional client-facing recovery guidance. */
+  /** Optional client-facing recovery guidance; it does not authorize action. */
   readonly fix?: string;
-  /** Optional client-facing documentation URL. */
+  /** Optional client-facing URL; verify its producer before following it. */
   readonly link?: string;
 }
 
@@ -161,8 +161,8 @@ export interface VercelErrorLike<
   /** Error scope included by `errorResponse()` when defined. */
   readonly scope?: string;
   /**
-   * Authored status mapping used by `errorResponse()`. Omission becomes 500;
-   * defined values must be integers from 400 through 599.
+   * Authored status mapping used by `errorResponse()`. Omission defaults to
+   * 500; invalid values cause `errorResponse()` to throw `RangeError`.
    */
   readonly statusCode?: number;
   /** Developer-facing explanation; responses use only `public.reason`. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,14 +38,12 @@ export type ErrorAttributes = Record<
 >;
 
 /**
- * Minimal interface for error-like objects with a message property.
+ * Minimal object shape recognized by {@link isErrorLike}. Only `message` is
+ * checked, and empty strings pass.
  */
 export interface ErrorLike {
-  /** Required string inspected by {@link isErrorLike}; blank strings pass. */
   message: string;
-  /** Optional descriptive error name; {@link isErrorLike} does not inspect it. */
   name?: string;
-  /** Optional diagnostic stack; {@link isErrorLike} does not inspect it. */
   stack?: string;
 }
 
@@ -61,15 +59,15 @@ export interface ErrorLike {
  * intended audience.
  */
 export interface PublicErrorDetails {
-  /** Required nonblank description explicitly approved for clients. */
+  /** Client-facing description containing non-whitespace text. */
   readonly message: string;
-  /** Optional client-approved explanation of why the error occurred. */
+  /** Optional client-facing explanation of why the error occurred. */
   readonly reason?: string;
-  /** Optional client-approved advisory guidance. */
+  /** Optional client-facing investigation advice. */
   readonly hint?: string;
-  /** Optional client-approved remediation suggestion, not authorization. */
+  /** Optional client-facing recovery guidance. */
   readonly fix?: string;
-  /** Optional client-approved URL; it does not establish trust or authority. */
+  /** Optional client-facing documentation URL. */
   readonly link?: string;
 }
 
@@ -158,19 +156,22 @@ export interface VercelErrorLike<
 > extends ErrorLike {
   /** Underlying diagnostic value; not sent in error responses. */
   readonly cause?: unknown;
-  /** Stable identity code sent to clients when defined. */
+  /** Stable machine-readable code included by `errorResponse()` when defined. */
   readonly code?: TCode;
-  /** Optional identity namespace sent to clients when defined. */
+  /** Error scope included by `errorResponse()` when defined. */
   readonly scope?: string;
-  /** Authored HTTP mapping, not a completed response status. */
+  /**
+   * Authored status mapping used by `errorResponse()`. Omission becomes 500;
+   * defined values must be integers from 400 through 599.
+   */
   readonly statusCode?: number;
-  /** Developer-facing explanation unless repeated under `public`. */
+  /** Developer-facing explanation; responses use only `public.reason`. */
   readonly reason?: string;
-  /** Developer-facing advice unless repeated under `public`. */
+  /** Developer-facing advice; responses use only `public.hint`. */
   readonly hint?: string;
-  /** Developer-facing remediation unless repeated under `public`. */
+  /** Developer-facing recovery guidance; responses use only `public.fix`. */
   readonly fix?: string;
-  /** Developer-facing URL unless repeated under `public`. */
+  /** Developer-facing URL; responses use only `public.link`. */
   readonly link?: string;
   /** Details explicitly approved for client responses. */
   readonly public?: PublicErrorDetails;

--- a/src/vercel-error/index.ts
+++ b/src/vercel-error/index.ts
@@ -10,18 +10,22 @@ import { VERCEL_ERROR_TAG } from './tag';
 
 /**
  * An `Error` subclass with stable identity, separate developer and public
- * details, cause chaining, diagnostic context, and terminal formatting.
+ * details, an original cause, debugging data, and terminal formatting.
  *
- * `message`, `reason`, `hint`, `fix`, and `link` are developer-facing. Put
- * client-facing text under `public`. Construction validates that object, drops
- * unknown fields, and stores a frozen copy; invalid fields throw `TypeError`.
+ * `message`, `reason`, `hint`, `fix`, and `link` are developer-facing.
+ * `errorResponse()` uses text from `public`, or a fixed generic message when
+ * `public` is absent. When `public` is provided, its `message` must contain
+ * non-whitespace text and its optional fields must be strings. Invalid fields
+ * throw `TypeError`; unknown fields are dropped and the copied object is frozen.
  *
- * The cross-realm symbol tag identifies data only and can be forged. Use
- * `instanceof VercelError` before calling class methods. `requestId`,
- * `metadata`, and `attributes` remain mutable. `message`, `scope`, `code`,
- * `statusCode`, the developer detail fields, and `public` are readonly.
- * Construction sets `name` to `"VercelError"`; subclasses that need another
- * stable name must assign it explicitly.
+ * Objects from another JavaScript realm can carry the package symbol tag, but
+ * any object can forge it. Use `instanceof VercelError` before calling class
+ * methods.
+ *
+ * TypeScript exposes `requestId`, `metadata`, and `attributes` as writable and
+ * the other fields declared below as readonly. This does not freeze the error
+ * instance. Construction sets `name` to `"VercelError"`; subclasses that need
+ * another stable name must assign it explicitly.
  *
  * @template TCode - Strongly typed error code union
  *
@@ -50,8 +54,8 @@ export class VercelError<TCode extends string = string> extends Error {
   readonly scope?: string;
 
   /**
-   * Authored HTTP mapping. `errorResponse()` defaults omission to 500 and
-   * accepts only integers from 400 through 599.
+   * Status mapping used by `errorResponse()`. Omission defaults to 500; defined
+   * values must be integers from 400 through 599.
    */
   readonly statusCode?: number;
 
@@ -66,17 +70,14 @@ export class VercelError<TCode extends string = string> extends Error {
    * include a URL in an error response.
    */
   readonly link?: string;
-  /**
-   * Client-approved details, validated and copied at construction. Unknown
-   * fields are dropped and the stored copy is frozen.
-   */
+  /** Public error details, validated and copied at construction. */
   readonly public?: PublicErrorDetails;
 
-  /** Mutable correlation value included in diagnostics but never responses. */
+  /** Mutable request ID included in `toJSON()` and excluded from responses. */
   requestId?: string;
-  /** Mutable nested diagnostic context included in `toJSON()`, never responses. */
+  /** Mutable nested debugging data included in `toJSON()`, not responses. */
   metadata?: ErrorMetadata;
-  /** Mutable flat telemetry context included in `toJSON()`, never responses. */
+  /** Mutable flat telemetry values included in `toJSON()`, not responses. */
   attributes?: ErrorAttributes;
 
   constructor(message: string, options: VercelErrorOptions<TCode> = {}) {
@@ -115,8 +116,8 @@ export class VercelError<TCode extends string = string> extends Error {
    * Surfaces non-enumerable Error properties (`name`, `message`, `stack`)
    * alongside all VercelError fields. Omits `cause` (may be circular or
    * contain sensitive internals) and any `undefined` values. This output may
-   * contain developer prose and server context; use `errorResponse()` for
-   * client-safe HTTP serialization.
+   * contain developer-facing text and server data; use `errorResponse()` for
+   * client-facing HTTP output.
    */
   toJSON(): Record<string, unknown> {
     return {

--- a/src/vercel-error/index.ts
+++ b/src/vercel-error/index.ts
@@ -18,9 +18,10 @@ import { VERCEL_ERROR_TAG } from './tag';
  *
  * The cross-realm symbol tag identifies data only and can be forged. Use
  * `instanceof VercelError` before calling class methods. `requestId`,
- * `metadata`, and `attributes` remain mutable; the other authored fields are
- * readonly. Construction sets `name` to `"VercelError"`; subclasses that need
- * another stable name must assign it explicitly.
+ * `metadata`, and `attributes` remain mutable. `message`, `scope`, `code`,
+ * `statusCode`, the developer detail fields, and `public` are readonly.
+ * Construction sets `name` to `"VercelError"`; subclasses that need another
+ * stable name must assign it explicitly.
  *
  * @template TCode - Strongly typed error code union
  *
@@ -132,9 +133,9 @@ export class VercelError<TCode extends string = string> extends Error {
   }
 
   /**
-   * Render developer-facing details with environment-detected formatting.
-   * This output may contain sensitive diagnostics; use `errorResponse()` for
-   * client-safe HTTP serialization.
+   * Render the developer-facing message, identity, reason, hint, fix, and link
+   * using environment-detected formatting. Use `errorResponse()` from
+   * `@vercel/error/server` for client-facing HTTP output.
    */
   override toString(): string {
     return formatError(this, { format: 'auto' });

--- a/src/vercel-error/index.ts
+++ b/src/vercel-error/index.ts
@@ -9,20 +9,18 @@ import type {
 import { VERCEL_ERROR_TAG } from './tag';
 
 /**
- * An Error subclass with stable identity, separate developer and public details,
- * diagnostic context, cause chaining, and terminal formatting.
+ * An `Error` subclass with stable identity, separate developer and public
+ * details, cause chaining, diagnostic context, and terminal formatting.
  *
- * `message` is required. `reason`, `hint`, `fix`, and `link` are optional
- * developer details; omit them when the cause or remediation is not known.
- * When `public` is supplied, construction validates it (nonblank string
- * `message`, optional string details), drops unknown fields, and stores a
- * frozen copy; invalid `public` details throw `TypeError` here rather than
- * later at serialization. Cross-realm recognition is data-only because the
- * symbol tag is forgeable; use `instanceof VercelError` before invoking class
- * methods. Construction sets `name` to `"VercelError"`; subclasses must assign
- * a different stable name explicitly. Identity and prose fields are readonly,
- * while `requestId`, `metadata`, and `attributes` remain mutable for diagnostic
- * enrichment.
+ * `message`, `reason`, `hint`, `fix`, and `link` are developer-facing. Put
+ * client-facing text under `public`. Construction validates that object, drops
+ * unknown fields, and stores a frozen copy; invalid fields throw `TypeError`.
+ *
+ * The cross-realm symbol tag identifies data only and can be forged. Use
+ * `instanceof VercelError` before calling class methods. `requestId`,
+ * `metadata`, and `attributes` remain mutable; the other authored fields are
+ * readonly. Construction sets `name` to `"VercelError"`; subclasses that need
+ * another stable name must assign it explicitly.
  *
  * @template TCode - Strongly typed error code union
  *
@@ -39,12 +37,15 @@ import { VERCEL_ERROR_TAG } from './tag';
  * ```
  */
 export class VercelError<TCode extends string = string> extends Error {
-  /** Developer-facing description of what failed; not approved for clients. */
+  /**
+   * Developer-facing message. `errorResponse()` uses `public.message` or a
+   * fixed generic message instead.
+   */
   declare readonly message: string;
 
-  /** Stable machine-readable identity sent to clients when defined. */
+  /** Stable machine-readable code included by `errorResponse()` when defined. */
   readonly code?: TCode;
-  /** Optional identity namespace sent to clients when defined. */
+  /** Error scope included by `errorResponse()` when defined. */
   readonly scope?: string;
 
   /**
@@ -55,11 +56,14 @@ export class VercelError<TCode extends string = string> extends Error {
 
   /** Developer-facing explanation of why the failure occurred. */
   readonly reason?: string;
-  /** Developer-facing advisory guidance rendered before `fix`. */
+  /** Developer-facing advice rendered before `fix`. */
   readonly hint?: string;
-  /** Developer-facing remediation suggestion; it does not authorize action. */
+  /** Developer-facing recovery guidance; it does not authorize action. */
   readonly fix?: string;
-  /** Developer-facing documentation URL; not automatically safe for clients. */
+  /**
+   * Developer-facing documentation URL. Set `public.link` separately to
+   * include a URL in an error response.
+   */
   readonly link?: string;
   /**
    * Client-approved details, validated and copied at construction. Unknown

--- a/src/vercel-error/index.ts
+++ b/src/vercel-error/index.ts
@@ -9,23 +9,10 @@ import type {
 import { VERCEL_ERROR_TAG } from './tag';
 
 /**
- * An `Error` subclass with stable identity, separate developer and public
- * details, an original cause, debugging data, and terminal formatting.
- *
- * `message`, `reason`, `hint`, `fix`, and `link` are developer-facing.
- * `errorResponse()` uses text from `public`, or a fixed generic message when
- * `public` is absent. When `public` is provided, its `message` must contain
- * non-whitespace text and its optional fields must be strings. Invalid fields
- * throw `TypeError`; unknown fields are dropped and the copied object is frozen.
- *
- * Objects from another JavaScript realm can carry the package symbol tag, but
- * any object can forge it. Use `instanceof VercelError` before calling class
- * methods.
- *
- * TypeScript exposes `requestId`, `metadata`, and `attributes` as writable and
- * the other fields declared below as readonly. This does not freeze the error
- * instance. Construction sets `name` to `"VercelError"`; subclasses that need
- * another stable name must assign it explicitly.
+ * An `Error` with stable identity and separate developer and client details.
+ * Developer text stays outside `public`; construction validates and freezes
+ * `public`. Use `instanceof VercelError` before calling methods on tagged data.
+ * Only `requestId`, `metadata`, and `attributes` are writable in TypeScript.
  *
  * @template TCode - Strongly typed error code union
  *
@@ -42,10 +29,7 @@ import { VERCEL_ERROR_TAG } from './tag';
  * ```
  */
 export class VercelError<TCode extends string = string> extends Error {
-  /**
-   * Developer-facing message. `errorResponse()` uses `public.message` or a
-   * fixed generic message instead.
-   */
+  /** Developer message; responses use `public.message` or a generic message. */
   declare readonly message: string;
 
   /** Stable machine-readable code included by `errorResponse()` when defined. */
@@ -53,10 +37,7 @@ export class VercelError<TCode extends string = string> extends Error {
   /** Error scope included by `errorResponse()` when defined. */
   readonly scope?: string;
 
-  /**
-   * Status mapping used by `errorResponse()`. Omission defaults to 500; defined
-   * values must be integers from 400 through 599.
-   */
+  /** HTTP status mapping; `errorResponse()` accepts 400-599 and defaults to 500. */
   readonly statusCode?: number;
 
   /** Developer-facing explanation of why the failure occurred. */
@@ -65,10 +46,7 @@ export class VercelError<TCode extends string = string> extends Error {
   readonly hint?: string;
   /** Developer-facing recovery guidance; it does not authorize action. */
   readonly fix?: string;
-  /**
-   * Developer-facing documentation URL. Set `public.link` separately to
-   * include a URL in an error response.
-   */
+  /** Developer URL; set `public.link` separately for responses. */
   readonly link?: string;
   /** Public error details, validated and copied at construction. */
   readonly public?: PublicErrorDetails;
@@ -111,13 +89,9 @@ export class VercelError<TCode extends string = string> extends Error {
   private static readonly JSON_EXCLUDE = new Set(['name', 'cause']);
 
   /**
-   * Diagnostic object used by `JSON.stringify`.
-   *
-   * Surfaces non-enumerable Error properties (`name`, `message`, `stack`)
-   * alongside all VercelError fields. Omits `cause` (may be circular or
-   * contain sensitive internals) and any `undefined` values. This output may
-   * contain developer-facing text and server data; use `errorResponse()` for
-   * client-facing HTTP output.
+   * Object used by `JSON.stringify`. Includes `name`, `message`, `stack`, and
+   * defined `VercelError` fields, but not `cause`. May contain developer and
+   * server data; use `errorResponse()` for client output.
    */
   toJSON(): Record<string, unknown> {
     return {
@@ -133,11 +107,7 @@ export class VercelError<TCode extends string = string> extends Error {
     };
   }
 
-  /**
-   * Render the developer-facing message, identity, reason, hint, fix, and link
-   * using environment-detected formatting. Use `errorResponse()` from
-   * `@vercel/error/server` for client-facing HTTP output.
-   */
+  /** Render developer fields; use `errorResponse()` for client-facing output. */
   override toString(): string {
     return formatError(this, { format: 'auto' });
   }

--- a/src/vercel-error/index.ts
+++ b/src/vercel-error/index.ts
@@ -19,7 +19,10 @@ import { VERCEL_ERROR_TAG } from './tag';
  * frozen copy; invalid `public` details throw `TypeError` here rather than
  * later at serialization. Cross-realm recognition is data-only because the
  * symbol tag is forgeable; use `instanceof VercelError` before invoking class
- * methods.
+ * methods. Construction sets `name` to `"VercelError"`; subclasses must assign
+ * a different stable name explicitly. Identity and prose fields are readonly,
+ * while `requestId`, `metadata`, and `attributes` remain mutable for diagnostic
+ * enrichment.
  *
  * @template TCode - Strongly typed error code union
  *
@@ -36,21 +39,39 @@ import { VERCEL_ERROR_TAG } from './tag';
  * ```
  */
 export class VercelError<TCode extends string = string> extends Error {
+  /** Developer-facing description of what failed; not approved for clients. */
   declare readonly message: string;
 
+  /** Stable machine-readable identity sent to clients when defined. */
   readonly code?: TCode;
+  /** Optional identity namespace sent to clients when defined. */
   readonly scope?: string;
 
+  /**
+   * Authored HTTP mapping. `errorResponse()` defaults omission to 500 and
+   * accepts only integers from 400 through 599.
+   */
   readonly statusCode?: number;
 
+  /** Developer-facing explanation of why the failure occurred. */
   readonly reason?: string;
+  /** Developer-facing advisory guidance rendered before `fix`. */
   readonly hint?: string;
+  /** Developer-facing remediation suggestion; it does not authorize action. */
   readonly fix?: string;
+  /** Developer-facing documentation URL; not automatically safe for clients. */
   readonly link?: string;
+  /**
+   * Client-approved details, validated and copied at construction. Unknown
+   * fields are dropped and the stored copy is frozen.
+   */
   readonly public?: PublicErrorDetails;
 
+  /** Mutable correlation value included in diagnostics but never responses. */
   requestId?: string;
+  /** Mutable nested diagnostic context included in `toJSON()`, never responses. */
   metadata?: ErrorMetadata;
+  /** Mutable flat telemetry context included in `toJSON()`, never responses. */
   attributes?: ErrorAttributes;
 
   constructor(message: string, options: VercelErrorOptions<TCode> = {}) {
@@ -107,8 +128,9 @@ export class VercelError<TCode extends string = string> extends Error {
   }
 
   /**
-   * Environment-aware string representation.
-   * Auto-detects ANSI support and renders accordingly.
+   * Render developer-facing details with environment-detected formatting.
+   * This output may contain sensitive diagnostics; use `errorResponse()` for
+   * client-safe HTTP serialization.
    */
   override toString(): string {
     return formatError(this, { format: 'auto' });

--- a/src/wants-ansi/index.ts
+++ b/src/wants-ansi/index.ts
@@ -23,7 +23,8 @@ export interface HeadersLike {
  * 2. `Accept: text/plain+ansi` header
  * 3. `User-Agent` containing `curl/` (curl users get ANSI by default)
  *
- * Returns `false` if no input is provided or none of the checks match.
+ * Returns `false` if no input is provided or none of the checks match. Header
+ * access and `get()` exceptions propagate.
  */
 export function wantsAnsi(
   requestOrHeaders?: Request | HeadersLike | null,

--- a/src/wants-ansi/index.ts
+++ b/src/wants-ansi/index.ts
@@ -8,6 +8,7 @@
  * headers stored in other casings.
  */
 export interface HeadersLike {
+  /** Look up a header case-insensitively; return `null` when it is absent. */
   get(name: string): string | null;
 }
 

--- a/src/wants-ansi/index.ts
+++ b/src/wants-ansi/index.ts
@@ -1,11 +1,6 @@
 /**
- * Minimal header lookup interface accepted by ANSI content negotiation.
- * Compatible with `Headers`, Next.js `ReadonlyHeaders`, and plain adapters.
- *
- * Negotiation looks up lowercase header names (`x-error-format`, `accept`,
- * `user-agent`), so `get` must match names case-insensitively, as WHATWG
- * `Headers` does. An adapter that only matches verbatim keys will miss
- * headers stored in other casings.
+ * Header lookup used by {@link wantsAnsi}. `get` must ignore name casing and
+ * return `null` when a header is absent.
  */
 export interface HeadersLike {
   get(name: string): string | null;
@@ -14,17 +9,10 @@ export interface HeadersLike {
 /**
  * Return whether a request selects an ANSI-formatted error response.
  *
- * Accepts a `Request` or a `HeadersLike` lookup. Checks these case-sensitive
- * values in order:
- *
- * 1. If `X-Error-Format` is present, return `true` only for the exact value
- *    `ansi`; do not check lower-priority headers.
- * 2. Return `true` if `Accept` contains `text/plain+ansi`.
- * 3. Return `true` if `User-Agent` contains `curl/`.
- *
- * Returns `false` when no input is provided or no check matches. Reading
- * headers or calling `get()` may invoke accessors or Proxy traps, and their
- * exceptions propagate.
+ * Checks exact, case-sensitive values in this order: `X-Error-Format` equal to
+ * `ansi`, `Accept` containing `text/plain+ansi`, then `User-Agent` containing
+ * `curl/`. A present `X-Error-Format` stops the later checks. Missing input or
+ * no match returns `false`; header-access exceptions propagate.
  */
 export function wantsAnsi(
   requestOrHeaders?: Request | HeadersLike | null,

--- a/src/wants-ansi/index.ts
+++ b/src/wants-ansi/index.ts
@@ -8,23 +8,23 @@
  * headers stored in other casings.
  */
 export interface HeadersLike {
-  /** Look up a header case-insensitively; return `null` when it is absent. */
   get(name: string): string | null;
 }
 
 /**
- * Detect whether an HTTP request wants ANSI-formatted error responses.
+ * Return whether a request selects an ANSI-formatted error response.
  *
- * Accepts a `Request` or `HeadersLike` object: any object with a `get(name)` method
- * (e.g. Next.js `ReadonlyHeaders`, `Headers`, etc).
+ * Accepts a `Request` or a `HeadersLike` lookup. Checks these case-sensitive
+ * values in order:
  *
- * Checks (in order):
- * 1. A present `X-Error-Format` header is authoritative; only `ansi` enables ANSI
- * 2. `Accept: text/plain+ansi` header
- * 3. `User-Agent` containing `curl/` (curl users get ANSI by default)
+ * 1. If `X-Error-Format` is present, return `true` only for the exact value
+ *    `ansi`; do not check lower-priority headers.
+ * 2. Return `true` if `Accept` contains `text/plain+ansi`.
+ * 3. Return `true` if `User-Agent` contains `curl/`.
  *
- * Returns `false` if no input is provided or none of the checks match. Header
- * access and `get()` exceptions propagate.
+ * Returns `false` when no input is provided or no check matches. Reading
+ * headers or calling `get()` may invoke accessors or Proxy traps, and their
+ * exceptions propagate.
  */
 export function wantsAnsi(
   requestOrHeaders?: Request | HeadersLike | null,


### PR DESCRIPTION
## Problem

The TypeScript declaration files appear in editor hints, but many public fields and type guards did not say which values reach clients, which fields may be changed, or which operations can throw.

`getMessage()` also read `message` twice. A getter could return a string during the check and a non-string as the result. If `JSON.stringify()` failed, reading `constructor.name` could also throw instead of returning the fallback text.

## Approach

The public comments now explain these behaviors for error fields, shared types, factories, type guards, response data, HTTP responses, and terminal formatting. The generated declaration files include the comments.

`getMessage()` now reads `message` once and returns the value it checked. If `constructor.name` is missing, is not a string, or throws when read, the fallback uses `Object`. The fallback text is now `[Name - JSON serialization failed]`.

The generated bundle is 187 B for `getMessage`, below its existing 190 B limit.

## Scope

This is PR 2 of 3 before the `front` application moves to this package. The only runtime change is the `getMessage()` fix. Public names, TypeScript signatures, HTTP response shapes, and runtime dependencies do not change.

The package version is `0.1.4`; the release workflow attempts publication after merge.