### PR TITLE
test: verify packed metadata and contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Verify public package metadata and reject unexpected files in the installed tarball.
+- Verify public package metadata and reject files outside the allowed package roots or build formats.
 
 ## 0.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vercel/error
 
+## 0.1.5
+
+### Patch Changes
+
+- Verify public package metadata and reject unexpected files in the installed tarball.
+
 ## 0.1.4
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/error",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A lightweight toolkit for structured, actionable errors for humans and agents",
   "license": "MIT",
   "author": "Vercel",

--- a/scripts/verify-packed-package.mjs
+++ b/scripts/verify-packed-package.mjs
@@ -174,7 +174,6 @@ function verifyPackedManifest(installedPackageRoot) {
     }
   }
 
-  let artifactCount = 0;
   for (const file of files) {
     if (file.split('/').some((segment) => segment.startsWith('.'))) {
       throw new Error(`Packed package contains hidden path ${file}`);
@@ -183,21 +182,75 @@ function verifyPackedManifest(installedPackageRoot) {
     if (!file.startsWith('dist/')) {
       throw new Error(`Packed package contains unexpected file ${file}`);
     }
-    if (/\.spec\.[^/]+$/.test(file)) {
-      throw new Error(`Packed package contains test file ${file}`);
+    if (file.slice('dist/'.length).includes('/')) {
+      throw new Error(`Packed package contains nested artifact ${file}`);
     }
-    if (
-      !['.d.ts', '.d.ts.map', '.js', '.js.map'].some((suffix) =>
-        file.endsWith(suffix),
-      )
-    ) {
-      throw new Error(`Packed package contains unexpected artifact ${file}`);
-    }
-    artifactCount += 1;
   }
 
-  if (artifactCount === 0) {
-    throw new Error('Packed package contains no dist artifacts');
+  const remainingArtifacts = new Set(
+    files.filter((file) => file.startsWith('dist/')),
+  );
+  for (const required of [
+    'dist/client.d.ts',
+    'dist/client.js',
+    'dist/format.d.ts',
+    'dist/format.d.ts.map',
+    'dist/format.js',
+    'dist/index.d.ts',
+    'dist/index.d.ts.map',
+    'dist/index.js',
+    'dist/index.js.map',
+    'dist/server.d.ts',
+    'dist/server.d.ts.map',
+    'dist/server.js',
+    'dist/server.js.map',
+  ]) {
+    if (!remainingArtifacts.delete(required)) {
+      throw new Error(`Packed package is missing artifact ${required}`);
+    }
+  }
+
+  for (const family of ['error-response-data', 'format', 'is-vercel-error']) {
+    consumeChunkFamily(remainingArtifacts, family, ['.js', '.js.map']);
+  }
+  for (const family of ['index', 'types']) {
+    consumeChunkFamily(remainingArtifacts, family, ['.d.ts', '.d.ts.map']);
+  }
+
+  if (remainingArtifacts.size > 0) {
+    throw new Error(
+      `Packed package contains unexpected artifacts: ${[...remainingArtifacts].toSorted().join(', ')}`,
+    );
+  }
+}
+
+function consumeChunkFamily(files, family, suffixes) {
+  const prefix = `dist/${family}-`;
+  const matches = [];
+  for (const file of files) {
+    if (!file.startsWith(prefix)) continue;
+    const suffix = suffixes.find((candidate) => file.endsWith(candidate));
+    if (!suffix) continue;
+    matches.push({
+      file,
+      hash: file.slice(prefix.length, -suffix.length),
+      suffix,
+    });
+  }
+
+  if (
+    matches.length !== suffixes.length ||
+    new Set(matches.map((match) => match.hash)).size !== 1 ||
+    new Set(matches.map((match) => match.suffix)).size !== suffixes.length ||
+    matches.some((match) => match.hash === '')
+  ) {
+    throw new Error(
+      `Packed package must contain one ${family} chunk with ${suffixes.join(' and ')}`,
+    );
+  }
+
+  for (const match of matches) {
+    files.delete(match.file);
   }
 }
 

--- a/scripts/verify-packed-package.mjs
+++ b/scripts/verify-packed-package.mjs
@@ -174,6 +174,7 @@ function verifyPackedManifest(installedPackageRoot) {
     }
   }
 
+  let artifactCount = 0;
   for (const file of files) {
     if (file.split('/').some((segment) => segment.startsWith('.'))) {
       throw new Error(`Packed package contains hidden path ${file}`);
@@ -182,75 +183,21 @@ function verifyPackedManifest(installedPackageRoot) {
     if (!file.startsWith('dist/')) {
       throw new Error(`Packed package contains unexpected file ${file}`);
     }
-    if (file.slice('dist/'.length).includes('/')) {
-      throw new Error(`Packed package contains nested artifact ${file}`);
+    if (/\.spec\.[^/]+$/.test(file)) {
+      throw new Error(`Packed package contains test file ${file}`);
     }
-  }
-
-  const remainingArtifacts = new Set(
-    files.filter((file) => file.startsWith('dist/')),
-  );
-  for (const required of [
-    'dist/client.d.ts',
-    'dist/client.js',
-    'dist/format.d.ts',
-    'dist/format.d.ts.map',
-    'dist/format.js',
-    'dist/index.d.ts',
-    'dist/index.d.ts.map',
-    'dist/index.js',
-    'dist/index.js.map',
-    'dist/server.d.ts',
-    'dist/server.d.ts.map',
-    'dist/server.js',
-    'dist/server.js.map',
-  ]) {
-    if (!remainingArtifacts.delete(required)) {
-      throw new Error(`Packed package is missing artifact ${required}`);
+    if (
+      !['.d.ts', '.d.ts.map', '.js', '.js.map'].some((suffix) =>
+        file.endsWith(suffix),
+      )
+    ) {
+      throw new Error(`Packed package contains unexpected artifact ${file}`);
     }
+    artifactCount += 1;
   }
 
-  for (const family of ['error-response-data', 'format', 'is-vercel-error']) {
-    consumeChunkFamily(remainingArtifacts, family, ['.js', '.js.map']);
-  }
-  for (const family of ['index', 'types']) {
-    consumeChunkFamily(remainingArtifacts, family, ['.d.ts', '.d.ts.map']);
-  }
-
-  if (remainingArtifacts.size > 0) {
-    throw new Error(
-      `Packed package contains unexpected artifacts: ${[...remainingArtifacts].toSorted().join(', ')}`,
-    );
-  }
-}
-
-function consumeChunkFamily(files, family, suffixes) {
-  const prefix = `dist/${family}-`;
-  const matches = [];
-  for (const file of files) {
-    if (!file.startsWith(prefix)) continue;
-    const suffix = suffixes.find((candidate) => file.endsWith(candidate));
-    if (!suffix) continue;
-    matches.push({
-      file,
-      hash: file.slice(prefix.length, -suffix.length),
-      suffix,
-    });
-  }
-
-  if (
-    matches.length !== suffixes.length ||
-    new Set(matches.map((match) => match.hash)).size !== 1 ||
-    new Set(matches.map((match) => match.suffix)).size !== suffixes.length ||
-    matches.some((match) => match.hash === '')
-  ) {
-    throw new Error(
-      `Packed package must contain one ${family} chunk with ${suffixes.join(' and ')}`,
-    );
-  }
-
-  for (const match of matches) {
-    files.delete(match.file);
+  if (artifactCount === 0) {
+    throw new Error('Packed package contains no dist artifacts');
   }
 }
 

--- a/scripts/verify-packed-package.mjs
+++ b/scripts/verify-packed-package.mjs
@@ -49,6 +49,12 @@ async function main() {
       ],
       { cwd: consumerDirectory, stdio: 'inherit' },
     );
+    const installedPackageRoot = join(
+      consumerDirectory,
+      'node_modules/@vercel/error',
+    );
+    verifyPackedMetadata(installedPackageRoot);
+    verifyPackedManifest(installedPackageRoot);
 
     writeFileSync(
       join(consumerDirectory, 'tsconfig.json'),
@@ -110,6 +116,112 @@ async function main() {
   } finally {
     rmSync(workspace, { force: true, recursive: true });
   }
+}
+
+function verifyPackedMetadata(installedPackageRoot) {
+  const installedPackage = JSON.parse(
+    readFileSync(join(installedPackageRoot, 'package.json'), 'utf8'),
+  );
+  const expectations = [
+    ['name', installedPackage.name, '@vercel/error'],
+    ['license', installedPackage.license, 'MIT'],
+    [
+      'repository.url',
+      installedPackage.repository?.url,
+      'git+https://github.com/vercel-labs/error.git',
+    ],
+    ['publishConfig.access', installedPackage.publishConfig?.access, 'public'],
+    ['type', installedPackage.type, 'module'],
+    ['sideEffects', installedPackage.sideEffects, false],
+    ['engines.node', installedPackage.engines?.node, '>=24'],
+  ];
+
+  for (const [field, actual, expected] of expectations) {
+    if (actual !== expected) {
+      throw new Error(
+        `Packed package ${field} must be ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}`,
+      );
+    }
+  }
+
+  if (
+    typeof installedPackage.exports !== 'object' ||
+    installedPackage.exports === null
+  ) {
+    throw new Error('Packed package exports must be an object');
+  }
+  for (const [subpath, target] of Object.entries(installedPackage.exports)) {
+    if (typeof target !== 'object' || target === null) {
+      throw new Error(`Packed export ${subpath} must use conditional exports`);
+    }
+    const conditions = Object.keys(target);
+    const typesIndex = conditions.indexOf('types');
+    const defaultIndex = conditions.indexOf('default');
+    if (typesIndex === -1 || defaultIndex === -1 || typesIndex > defaultIndex) {
+      throw new Error(
+        `Packed export ${subpath} must declare types before default`,
+      );
+    }
+  }
+}
+
+function verifyPackedManifest(installedPackageRoot) {
+  const files = listPackedFiles(installedPackageRoot);
+  const requiredRootFiles = ['LICENSE', 'README.md', 'package.json'];
+  for (const required of requiredRootFiles) {
+    if (!files.includes(required)) {
+      throw new Error(`Packed package is missing ${required}`);
+    }
+  }
+
+  let artifactCount = 0;
+  for (const file of files) {
+    if (file.split('/').some((segment) => segment.startsWith('.'))) {
+      throw new Error(`Packed package contains hidden path ${file}`);
+    }
+    if (requiredRootFiles.includes(file)) continue;
+    if (!file.startsWith('dist/')) {
+      throw new Error(`Packed package contains unexpected file ${file}`);
+    }
+    if (/\.spec\.[^/]+$/.test(file)) {
+      throw new Error(`Packed package contains test file ${file}`);
+    }
+    if (
+      !['.d.ts', '.d.ts.map', '.js', '.js.map'].some((suffix) =>
+        file.endsWith(suffix),
+      )
+    ) {
+      throw new Error(`Packed package contains unexpected artifact ${file}`);
+    }
+    artifactCount += 1;
+  }
+
+  if (artifactCount === 0) {
+    throw new Error('Packed package contains no dist artifacts');
+  }
+}
+
+function listPackedFiles(directory, relativeDirectory = '') {
+  const files = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const relativePath = relativeDirectory
+      ? `${relativeDirectory}/${entry.name}`
+      : entry.name;
+    if (entry.isSymbolicLink()) {
+      throw new Error(`Packed package contains symbolic link ${relativePath}`);
+    }
+    if (entry.isDirectory()) {
+      files.push(...listPackedFiles(join(directory, entry.name), relativePath));
+      continue;
+    }
+    if (!entry.isFile()) {
+      throw new Error(
+        `Packed package contains unsupported entry ${relativePath}`,
+      );
+    }
+    files.push(relativePath);
+  }
+  return files.toSorted();
 }
 
 function verifyBuiltImports(distDirectory) {


### PR DESCRIPTION
## Problem

A package can pass runtime and type checks while publishing the wrong npm metadata or repository files that do not belong in the package. The release audit already found one such gap when the MIT license file shipped without a matching `package.json` license field.

## Approach

The packed-package check now reads metadata from the installed tarball and verifies the package name, MIT license, repository, public access, ESM format, side-effect flag, Node version range, and `types`-before-`default` export ordering.

It requires `LICENSE`, `README.md`, and `package.json`. Every other installed file must be a non-hidden build artifact under `dist/`, must not be a test, and must use a supported JavaScript, declaration, or source-map suffix. Existing checks still prove that every public runtime and type export exists and that built imports resolve without cycles. Internal chunk names, hashes, map companions, counts, and directory layout are not treated as public contracts.

## Watch out

This verifies the tarball produced by `pnpm pack` and installed by npm. The release workflow later rebuilds and repacks from the same commit with `npm publish`; current pnpm and npm dry runs contain the same 26 paths, but the workflow does not publish the exact tarball inspected here. Publishing the same verified tarball is a separate release-workflow change.

This is PR 3 of 3 before the `front` application moves to this package. It publishes `0.1.5` after merge.